### PR TITLE
Implement streaming Chapter 10 reader and file index

### DIFF
--- a/cmd/ch10ctl/main.go
+++ b/cmd/ch10ctl/main.go
@@ -34,7 +34,7 @@ func main() {
 }
 
 func usage() {
-	fmt.Println(`ch10ctl <command> [options]
+	fmt.Print(`ch10ctl <command> [options]
 
 Commands:
   validate  --in <file> --profile <profile> --rules <rulepack.json> --tmats <file> --out <diagnostics.jsonl> --acceptance <acceptance.json>

--- a/internal/ch10/parser.go
+++ b/internal/ch10/parser.go
@@ -9,16 +9,28 @@ import (
 	"example.com/ch10gate/internal/common"
 )
 
+const (
+	syncPattern         = 0xEB25
+	primaryHeaderSize   = 20
+	defaultResyncWindow = 64 * 1024
+)
+
 var (
 	ErrNoSync = errors.New("sync pattern 0xEB25 not found at expected position")
 )
 
 func ParsePrimaryHeader(r io.ReaderAt, offset int64) (PacketHeader, error) {
 	var hdr PacketHeader
-	buf := make([]byte, 20)
-	_, err := r.ReadAt(buf, offset)
+	buf := make([]byte, primaryHeaderSize)
+	n, err := r.ReadAt(buf, offset)
 	if err != nil {
+		if errors.Is(err, io.EOF) && n < primaryHeaderSize {
+			return hdr, io.ErrUnexpectedEOF
+		}
 		return hdr, err
+	}
+	if n < primaryHeaderSize {
+		return hdr, io.ErrUnexpectedEOF
 	}
 	hdr.Sync = binary.BigEndian.Uint16(buf[0:2])
 	hdr.ChannelID = binary.BigEndian.Uint16(buf[2:4])
@@ -30,50 +42,196 @@ func ParsePrimaryHeader(r io.ReaderAt, offset int64) (PacketHeader, error) {
 	return hdr, nil
 }
 
-func ScanFileMin(path string) (PacketHeader, FileIndex, error) {
-	var idx FileIndex
+// Reader iterates across a Chapter 10 file sequentially while building an index
+// of packet metadata.
+type Reader struct {
+	file         *os.File
+	size         int64
+	offset       int64
+	resyncWindow int64
+	resyncBuf    []byte
+
+	primary    PacketHeader
+	primarySet bool
+	index      FileIndex
+}
+
+// NewReader opens the file at path and prepares an iterator.
+func NewReader(path string) (*Reader, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return PacketHeader{}, idx, err
+		return nil, err
 	}
-	defer f.Close()
-
-	hdr, err := ParsePrimaryHeader(f, 0)
+	info, err := f.Stat()
 	if err != nil {
-		return hdr, idx, err
+		f.Close()
+		return nil, err
 	}
-	if hdr.Sync != 0xEB25 {
-		buf := make([]byte, 4096)
-		_, _ = f.ReadAt(buf, 0)
-		found := int64(-1)
-		for i := 0; i < len(buf)-1; i++ {
-			if buf[i] == 0xEB && buf[i+1] == 0x25 {
-				found = int64(i)
-				break
+	return &Reader{
+		file:         f,
+		size:         info.Size(),
+		resyncWindow: defaultResyncWindow,
+		resyncBuf:    make([]byte, defaultResyncWindow),
+	}, nil
+}
+
+// Close releases the underlying file handle.
+func (r *Reader) Close() error {
+	if r.file == nil {
+		return nil
+	}
+	err := r.file.Close()
+	r.file = nil
+	return err
+}
+
+// PrimaryHeader returns the first successfully parsed packet header.
+func (r *Reader) PrimaryHeader() (PacketHeader, bool) {
+	if !r.primarySet {
+		return PacketHeader{}, false
+	}
+	return r.primary, true
+}
+
+// Index returns a copy of the accumulated file index.
+func (r *Reader) Index() FileIndex {
+	out := FileIndex{
+		Packets: make([]PacketIndex, len(r.index.Packets)),
+	}
+	copy(out.Packets, r.index.Packets)
+	return out
+}
+
+// Next advances to the next packet header. It returns io.EOF when the end of
+// the file is reached.
+func (r *Reader) Next() (PacketHeader, PacketIndex, error) {
+	if r.file == nil {
+		return PacketHeader{}, PacketIndex{}, io.EOF
+	}
+	for {
+		if r.offset+primaryHeaderSize > r.size {
+			if r.offset >= r.size {
+				return PacketHeader{}, PacketIndex{}, io.EOF
 			}
+			return PacketHeader{}, PacketIndex{}, io.ErrUnexpectedEOF
 		}
-		if found >= 0 {
-			common.Logf("Sync pattern found at offset %d; attempting reparse", found)
-			hdr, err = ParsePrimaryHeader(f, found)
-			if err != nil {
-				return hdr, idx, err
+		hdr, err := ParsePrimaryHeader(r.file, r.offset)
+		if err != nil {
+			if errors.Is(err, io.ErrUnexpectedEOF) {
+				return PacketHeader{}, PacketIndex{}, err
 			}
-			idx.Packets = append(idx.Packets, PacketIndex{
-				Offset:    found,
-				ChannelID: hdr.ChannelID,
-				DataType:  hdr.DataType,
-				SeqNum:    hdr.SeqNum,
-			})
-			return hdr, idx, nil
+			return PacketHeader{}, PacketIndex{}, err
 		}
-		return hdr, idx, ErrNoSync
+		if hdr.Sync != syncPattern {
+			if err := r.resync("sync pattern"); err != nil {
+				return PacketHeader{}, PacketIndex{}, err
+			}
+			continue
+		}
+
+		totalLen := int64(hdr.PacketLength) + 4
+		if totalLen < primaryHeaderSize {
+			if err := r.resync("packet length too small"); err != nil {
+				return PacketHeader{}, PacketIndex{}, err
+			}
+			continue
+		}
+		nextOffset := r.offset + totalLen
+		if nextOffset > r.size {
+			if err := r.resync("packet length beyond file"); err != nil {
+				return PacketHeader{}, PacketIndex{}, err
+			}
+			continue
+		}
+
+		if !r.primarySet {
+			r.primary = hdr
+			r.primarySet = true
+		}
+
+		idx := PacketIndex{
+			Offset:       r.offset,
+			ChannelID:    hdr.ChannelID,
+			DataType:     hdr.DataType,
+			SeqNum:       hdr.SeqNum,
+			Flags:        hdr.Flags,
+			PacketLength: hdr.PacketLength,
+			DataLength:   hdr.DataLength,
+		}
+		r.index.Packets = append(r.index.Packets, idx)
+
+		r.offset = nextOffset
+		return hdr, idx, nil
+	}
+}
+
+func (r *Reader) resync(reason string) error {
+	common.Logf("resync at offset %d: %s", r.offset, reason)
+	start := r.offset + 1
+	if start >= r.size {
+		r.offset = r.size
+		return io.EOF
+	}
+	limit := start + r.resyncWindow
+	if limit > r.size {
+		limit = r.size
+	}
+	window := limit - start
+	if window < 2 {
+		r.offset = limit
+		return io.EOF
+	}
+	if int64(len(r.resyncBuf)) < window {
+		r.resyncBuf = make([]byte, window)
+	}
+	buf := r.resyncBuf[:window]
+	n, err := r.file.ReadAt(buf, start)
+	if n < 2 && err != nil {
+		if errors.Is(err, io.EOF) {
+			r.offset = r.size
+			return io.EOF
+		}
+		return err
+	}
+	for i := 0; i < n-1; i++ {
+		if buf[i] == 0xEB && buf[i+1] == 0x25 {
+			r.offset = start + int64(i)
+			common.Logf("resync successful, new offset %d", r.offset)
+			return nil
+		}
+	}
+	r.offset = limit
+	if limit >= r.size || errors.Is(err, io.EOF) {
+		return io.EOF
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return ErrNoSync
+}
+
+func ScanFileMin(path string) (PacketHeader, FileIndex, error) {
+	reader, err := NewReader(path)
+	if err != nil {
+		return PacketHeader{}, FileIndex{}, err
+	}
+	defer reader.Close()
+
+	for {
+		_, _, err := reader.Next()
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		return PacketHeader{}, FileIndex{}, err
 	}
 
-	idx.Packets = append(idx.Packets, PacketIndex{
-		Offset:    0,
-		ChannelID: hdr.ChannelID,
-		DataType:  hdr.DataType,
-		SeqNum:    hdr.SeqNum,
-	})
+	idx := reader.Index()
+	hdr, ok := reader.PrimaryHeader()
+	if !ok {
+		return PacketHeader{}, idx, ErrNoSync
+	}
 	return hdr, idx, nil
 }

--- a/internal/ch10/types.go
+++ b/internal/ch10/types.go
@@ -1,23 +1,26 @@
 package ch10
 
 type PacketHeader struct {
-	Sync          uint16
-	ChannelID     uint16
-	PacketLength  uint32
-	DataLength    uint32
-	DataType      uint16
-	SeqNum        uint8
-	Flags         uint8
+	Sync         uint16
+	ChannelID    uint16
+	PacketLength uint32
+	DataLength   uint32
+	DataType     uint16
+	SeqNum       uint8
+	Flags        uint8
 }
 
 type PacketIndex struct {
-	Offset      int64
-	ChannelID   uint16
-	DataType    uint16
-	SeqNum      uint8
-	HasSecHdr   bool
-	HasTrailer  bool
-	TimeStampUs int64
+	Offset       int64
+	ChannelID    uint16
+	DataType     uint16
+	SeqNum       uint8
+	Flags        uint8
+	PacketLength uint32
+	DataLength   uint32
+	HasSecHdr    bool
+	HasTrailer   bool
+	TimeStampUs  int64
 }
 
 type FileIndex struct {

--- a/internal/rules/engine.go
+++ b/internal/rules/engine.go
@@ -4,8 +4,11 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"time"
+
+	"example.com/ch10gate/internal/ch10"
 )
 
 type Severity string
@@ -17,16 +20,16 @@ const (
 )
 
 type Rule struct {
-	RuleId     string            `json:"ruleId"`
-	Name       string            `json:"name,omitempty"`
-	Scope      string            `json:"scope"` // packet|channel|file|tmats
-	AppliesTo  map[string]any    `json:"appliesTo,omitempty"`
-	Severity   Severity          `json:"severity"`
-	Fixable    bool              `json:"fixable"`
-	FixFunc    string            `json:"fixFunction,omitempty"`
-	Refs       []string          `json:"refs"`
-	Params     map[string]any    `json:"params,omitempty"`
-	Message    string            `json:"message"`
+	RuleId    string         `json:"ruleId"`
+	Name      string         `json:"name,omitempty"`
+	Scope     string         `json:"scope"` // packet|channel|file|tmats
+	AppliesTo map[string]any `json:"appliesTo,omitempty"`
+	Severity  Severity       `json:"severity"`
+	Fixable   bool           `json:"fixable"`
+	FixFunc   string         `json:"fixFunction,omitempty"`
+	Refs      []string       `json:"refs"`
+	Params    map[string]any `json:"params,omitempty"`
+	Message   string         `json:"message"`
 }
 
 type RulePack struct {
@@ -37,40 +40,78 @@ type RulePack struct {
 }
 
 type Diagnostic struct {
-	Ts          time.Time `json:"ts"`
-	File        string    `json:"file"`
-	ChannelId   int       `json:"channelId,omitempty"`
-	PacketIndex int       `json:"packetIndex,omitempty"`
-	Offset      string    `json:"offset,omitempty"`
-	RuleId      string    `json:"ruleId"`
-	Severity    Severity  `json:"severity"`
-	Message     string    `json:"message"`
-	Refs        []string  `json:"refs"`
-	FixSuggested bool     `json:"fixSuggested"`
-	FixApplied  bool      `json:"fixApplied"`
-	FixPatchId  string    `json:"fixPatchId,omitempty"`
+	Ts           time.Time `json:"ts"`
+	File         string    `json:"file"`
+	ChannelId    int       `json:"channelId,omitempty"`
+	PacketIndex  int       `json:"packetIndex,omitempty"`
+	Offset       string    `json:"offset,omitempty"`
+	RuleId       string    `json:"ruleId"`
+	Severity     Severity  `json:"severity"`
+	Message      string    `json:"message"`
+	Refs         []string  `json:"refs"`
+	FixSuggested bool      `json:"fixSuggested"`
+	FixApplied   bool      `json:"fixApplied"`
+	FixPatchId   string    `json:"fixPatchId,omitempty"`
 }
 
 type AcceptanceReport struct {
 	Summary struct {
-		Total   int  `json:"total"`
-		Errors  int  `json:"errors"`
-		Warnings int `json:"warnings"`
-		Pass    bool `json:"pass"`
+		Total    int  `json:"total"`
+		Errors   int  `json:"errors"`
+		Warnings int  `json:"warnings"`
+		Pass     bool `json:"pass"`
 	} `json:"summary"`
 	GateMatrix []map[string]any `json:"gateMatrix"`
-	Findings   []Diagnostic      `json:"findings,omitempty"`
+	Findings   []Diagnostic     `json:"findings,omitempty"`
 }
 
 type Context struct {
 	InputFile string
 	TMATSFile string
 	Profile   string
+
+	PrimaryHeader *ch10.PacketHeader
+	Index         *ch10.FileIndex
 }
 
-type Engine struct{
-	rulePack RulePack
-	registry map[string]FixFunc
+func (ctx *Context) EnsureFileIndex() error {
+	if ctx == nil {
+		return errors.New("nil context")
+	}
+	if ctx.InputFile == "" {
+		return nil
+	}
+	if ctx.Index != nil {
+		return nil
+	}
+	reader, err := ch10.NewReader(ctx.InputFile)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	for {
+		_, _, err := reader.Next()
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		return err
+	}
+	hdr, ok := reader.PrimaryHeader()
+	if !ok {
+		return ch10.ErrNoSync
+	}
+	idx := reader.Index()
+	ctx.Index = &idx
+	ctx.PrimaryHeader = &hdr
+	return nil
+}
+
+type Engine struct {
+	rulePack    RulePack
+	registry    map[string]FixFunc
 	diagnostics []Diagnostic
 }
 
@@ -88,6 +129,12 @@ func (e *Engine) Register(name string, f FixFunc) {
 }
 
 func (e *Engine) Eval(ctx *Context) ([]Diagnostic, error) {
+	if ctx == nil {
+		return nil, errors.New("nil context")
+	}
+	if err := ctx.EnsureFileIndex(); err != nil {
+		return nil, err
+	}
 	var diags []Diagnostic
 	for _, r := range e.rulePack.Rules {
 		if r.FixFunc == "" {
@@ -115,13 +162,16 @@ func (e *Engine) Eval(ctx *Context) ([]Diagnostic, error) {
 
 func (e *Engine) WriteDiagnosticsNDJSON(path string) error {
 	f, err := os.Create(path)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer f.Close()
 	w := bufio.NewWriter(f)
 	defer w.Flush()
 	for _, d := range e.diagnostics {
 		b, _ := json.Marshal(d)
-		w.Write(b); w.WriteString("\n")
+		w.Write(b)
+		w.WriteString("\n")
 	}
 	return nil
 }
@@ -148,7 +198,9 @@ func (e *Engine) MakeAcceptance() AcceptanceReport {
 func LoadRulePack(path string) (RulePack, error) {
 	var rp RulePack
 	b, err := os.ReadFile(path)
-	if err != nil { return rp, err }
+	if err != nil {
+		return rp, err
+	}
 	err = json.Unmarshal(b, &rp)
 	return rp, err
 }


### PR DESCRIPTION
## Summary
- add a streaming Chapter 10 reader that resynchronizes on malformed packets and populates a file-wide index
- extend packet metadata structures and expose the parsed index through the rules engine so built-ins can reuse it
- tidy the CLI usage banner while wiring the new index loader into existing workflows

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68cdab8c47a0832884e001de8cea6bfe