### PR TITLE
Add Chapter 10 checksum and length auto-fixes

### DIFF
--- a/internal/ch10/patch.go
+++ b/internal/ch10/patch.go
@@ -1,0 +1,70 @@
+package ch10
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+)
+
+// PatchEdit represents an in-place modification to a Chapter 10 file.
+type PatchEdit struct {
+	Offset int64
+	Data   []byte
+}
+
+// ApplyPatch applies the provided edits to path. Each edit must stay within the
+// bounds of the file and does not change its length.
+func ApplyPatch(path string, edits []PatchEdit) error {
+	if len(edits) == 0 {
+		return nil
+	}
+	// Make a defensive copy so callers can reuse the slice after return.
+	ordered := make([]PatchEdit, 0, len(edits))
+	for _, e := range edits {
+		if len(e.Data) == 0 {
+			continue
+		}
+		buf := make([]byte, len(e.Data))
+		copy(buf, e.Data)
+		ordered = append(ordered, PatchEdit{Offset: e.Offset, Data: buf})
+	}
+	if len(ordered) == 0 {
+		return nil
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Offset < ordered[j].Offset
+	})
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	size := info.Size()
+	for _, edit := range ordered {
+		if edit.Offset < 0 {
+			return fmt.Errorf("negative patch offset %d", edit.Offset)
+		}
+		end := edit.Offset + int64(len(edit.Data))
+		if end > size {
+			return fmt.Errorf("patch at %d with length %d exceeds file size %d", edit.Offset, len(edit.Data), size)
+		}
+		if _, err := f.Seek(edit.Offset, io.SeekStart); err != nil {
+			return err
+		}
+		written := 0
+		for written < len(edit.Data) {
+			n, err := f.Write(edit.Data[written:])
+			if err != nil {
+				return err
+			}
+			written += n
+		}
+	}
+	return f.Sync()
+}

--- a/internal/rules/builtin.go
+++ b/internal/rules/builtin.go
@@ -1,14 +1,19 @@
 package rules
 
 import (
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"time"
 
+	"example.com/ch10gate/internal/ch10"
 	"example.com/ch10gate/internal/tmats"
 )
+
+const ch10PrimaryHeaderSize = 20
 
 func (e *Engine) RegisterBuiltins() {
 	e.Register("CheckSyncPattern", CheckSyncPattern)
@@ -60,17 +65,201 @@ func CheckSyncPattern(ctx *Context, rule Rule) (Diagnostic, bool, error) {
 }
 
 func FixHeaderChecksum(ctx *Context, rule Rule) (Diagnostic, bool, error) {
-	return Diagnostic{
-		Ts: time.Now(), File: ctx.InputFile, RuleId: rule.RuleId, Severity: WARN,
-		Message: "header checksum check/fix not implemented yet", Refs: rule.Refs, FixSuggested: false,
-	}, false, ErrNotImplemented
+	diag := Diagnostic{
+		Ts:       time.Now(),
+		File:     ctx.InputFile,
+		RuleId:   rule.RuleId,
+		Severity: INFO,
+		Message:  "header checksum verification skipped",
+		Refs:     rule.Refs,
+	}
+	if ctx == nil || ctx.InputFile == "" {
+		diag.Severity = ERROR
+		diag.Message = "no input file provided"
+		return diag, false, errors.New("no input file")
+	}
+	if ctx.Index == nil {
+		if err := ctx.EnsureFileIndex(); err != nil {
+			diag.Severity = ERROR
+			diag.Message = "cannot index file"
+			return diag, false, err
+		}
+	}
+	if ctx.Index == nil || len(ctx.Index.Packets) == 0 {
+		diag.Message = "no packets to inspect"
+		return diag, false, nil
+	}
+	f, err := os.Open(ctx.InputFile)
+	if err != nil {
+		diag.Severity = ERROR
+		diag.Message = "cannot open input file"
+		return diag, false, err
+	}
+	defer f.Close()
+
+	header := make([]byte, ch10PrimaryHeaderSize)
+	var edits []ch10.PatchEdit
+	var mismatched int
+	for _, pkt := range ctx.Index.Packets {
+		if _, err := f.ReadAt(header, pkt.Offset); err != nil {
+			diag.Severity = ERROR
+			diag.Message = fmt.Sprintf("read header at offset %d failed", pkt.Offset)
+			return diag, false, err
+		}
+		stored := binary.BigEndian.Uint16(header[16:18])
+		computed, err := ch10.ComputeHeaderChecksum(ctx.Profile, header)
+		if err != nil {
+			diag.Severity = ERROR
+			diag.Message = "cannot compute header checksum"
+			return diag, false, err
+		}
+		if stored == computed {
+			continue
+		}
+		mismatched++
+		buf := []byte{byte(computed >> 8), byte(computed)}
+		edits = append(edits, ch10.PatchEdit{Offset: pkt.Offset + 16, Data: buf})
+	}
+
+	if mismatched == 0 {
+		diag.Message = "header checksums verified"
+		return diag, false, nil
+	}
+	if err := ch10.ApplyPatch(ctx.InputFile, edits); err != nil {
+		diag.Severity = ERROR
+		diag.Message = "failed to update header checksum"
+		return diag, false, err
+	}
+	diag.Message = fmt.Sprintf("fixed header checksum on %d packets", mismatched)
+	diag.FixSuggested = true
+	return diag, true, nil
 }
 
 func FixDataChecksumOrTrailer(ctx *Context, rule Rule) (Diagnostic, bool, error) {
-	return Diagnostic{
-		Ts: time.Now(), File: ctx.InputFile, RuleId: rule.RuleId, Severity: WARN,
-		Message: "data checksum fix not implemented yet", Refs: rule.Refs,
-	}, false, ErrNotImplemented
+	diag := Diagnostic{
+		Ts:       time.Now(),
+		File:     ctx.InputFile,
+		RuleId:   rule.RuleId,
+		Severity: INFO,
+		Message:  "data checksum verification skipped",
+		Refs:     rule.Refs,
+	}
+	if ctx == nil || ctx.InputFile == "" {
+		diag.Severity = ERROR
+		diag.Message = "no input file provided"
+		return diag, false, errors.New("no input file")
+	}
+	if ctx.Index == nil {
+		if err := ctx.EnsureFileIndex(); err != nil {
+			diag.Severity = ERROR
+			diag.Message = "cannot index file"
+			return diag, false, err
+		}
+	}
+	if ctx.Index == nil || len(ctx.Index.Packets) == 0 {
+		diag.Message = "no packets to inspect"
+		return diag, false, nil
+	}
+	f, err := os.Open(ctx.InputFile)
+	if err != nil {
+		diag.Severity = ERROR
+		diag.Message = "cannot open input file"
+		return diag, false, err
+	}
+	info, statErr := f.Stat()
+	if statErr != nil {
+		f.Close()
+		diag.Severity = ERROR
+		diag.Message = "cannot stat input file"
+		return diag, false, statErr
+	}
+	size := info.Size()
+	header := make([]byte, ch10PrimaryHeaderSize)
+	buf := make([]byte, 64*1024)
+	var edits []ch10.PatchEdit
+	var mismatched int
+
+	for _, pkt := range ctx.Index.Packets {
+		if _, err := f.ReadAt(header, pkt.Offset); err != nil {
+			f.Close()
+			diag.Severity = ERROR
+			diag.Message = fmt.Sprintf("read header at offset %d failed", pkt.Offset)
+			return diag, false, err
+		}
+		storedChecksum := binary.BigEndian.Uint16(header[18:20])
+		pktLen := binary.BigEndian.Uint32(header[4:8])
+		totalLen := int64(pktLen) + 4
+		if totalLen < ch10PrimaryHeaderSize {
+			continue
+		}
+		dataOffset := pkt.Offset + ch10PrimaryHeaderSize
+		if dataOffset >= size {
+			continue
+		}
+		dataLen := totalLen - ch10PrimaryHeaderSize
+		maxAvail := size - dataOffset
+		if maxAvail < 0 {
+			maxAvail = 0
+		}
+		if dataLen > maxAvail {
+			dataLen = maxAvail
+		}
+		remaining := dataLen
+		calc, err := ch10.NewDataChecksum(ctx.Profile)
+		if err != nil {
+			f.Close()
+			diag.Severity = ERROR
+			diag.Message = "cannot init data checksum"
+			return diag, false, err
+		}
+		offset := dataOffset
+		for remaining > 0 {
+			chunk := int64(len(buf))
+			if remaining < chunk {
+				chunk = remaining
+			}
+			if chunk <= 0 {
+				break
+			}
+			n, err := f.ReadAt(buf[:int(chunk)], offset)
+			if err != nil && err != io.EOF {
+				f.Close()
+				diag.Severity = ERROR
+				diag.Message = fmt.Sprintf("read payload at offset %d failed", offset)
+				return diag, false, err
+			}
+			if n == 0 {
+				break
+			}
+			calc.Write(buf[:n])
+			remaining -= int64(n)
+			offset += int64(n)
+			if int64(n) < chunk {
+				break
+			}
+		}
+		computed := calc.Sum16()
+		if computed == storedChecksum {
+			continue
+		}
+		mismatched++
+		buf2 := []byte{byte(computed >> 8), byte(computed)}
+		edits = append(edits, ch10.PatchEdit{Offset: pkt.Offset + 18, Data: buf2})
+	}
+	f.Close()
+
+	if mismatched == 0 {
+		diag.Message = "data checksums verified"
+		return diag, false, nil
+	}
+	if err := ch10.ApplyPatch(ctx.InputFile, edits); err != nil {
+		diag.Severity = ERROR
+		diag.Message = "failed to update data checksum"
+		return diag, false, err
+	}
+	diag.Message = fmt.Sprintf("fixed data checksum on %d packets", mismatched)
+	diag.FixSuggested = true
+	return diag, true, nil
 }
 
 func SyncSecondaryHeaderFlag(ctx *Context, rule Rule) (Diagnostic, bool, error) {
@@ -81,10 +270,193 @@ func SyncSecondaryHeaderFlag(ctx *Context, rule Rule) (Diagnostic, bool, error) 
 }
 
 func FixLengths(ctx *Context, rule Rule) (Diagnostic, bool, error) {
-	return Diagnostic{
-		Ts: time.Now(), File: ctx.InputFile, RuleId: rule.RuleId, Severity: WARN,
-		Message: "packet/data length recompute not implemented yet", Refs: rule.Refs,
-	}, false, ErrNotImplemented
+	diag := Diagnostic{
+		Ts:       time.Now(),
+		File:     ctx.InputFile,
+		RuleId:   rule.RuleId,
+		Severity: INFO,
+		Message:  "length verification skipped",
+		Refs:     rule.Refs,
+	}
+	if ctx == nil || ctx.InputFile == "" {
+		diag.Severity = ERROR
+		diag.Message = "no input file provided"
+		return diag, false, errors.New("no input file")
+	}
+	if ctx.Index == nil {
+		if err := ctx.EnsureFileIndex(); err != nil {
+			diag.Severity = ERROR
+			diag.Message = "cannot index file"
+			return diag, false, err
+		}
+	}
+	if ctx.Index == nil || len(ctx.Index.Packets) == 0 {
+		diag.Message = "no packets to inspect"
+		return diag, false, nil
+	}
+	f, err := os.Open(ctx.InputFile)
+	if err != nil {
+		diag.Severity = ERROR
+		diag.Message = "cannot open input file"
+		return diag, false, err
+	}
+	info, statErr := f.Stat()
+	if statErr != nil {
+		f.Close()
+		diag.Severity = ERROR
+		diag.Message = "cannot stat input file"
+		return diag, false, statErr
+	}
+	size := info.Size()
+	header := make([]byte, ch10PrimaryHeaderSize)
+	buf := make([]byte, 64*1024)
+
+	var edits []ch10.PatchEdit
+	var fixed int
+
+	for _, pkt := range ctx.Index.Packets {
+		if _, err := f.ReadAt(header, pkt.Offset); err != nil {
+			f.Close()
+			diag.Severity = ERROR
+			diag.Message = fmt.Sprintf("read header at offset %d failed", pkt.Offset)
+			return diag, false, err
+		}
+		storedPacketLen := binary.BigEndian.Uint32(header[4:8])
+		storedDataLen := binary.BigEndian.Uint32(header[8:12])
+		storedChecksum := binary.BigEndian.Uint16(header[18:20])
+
+		totalLen := int64(storedPacketLen) + 4
+		if totalLen < ch10PrimaryHeaderSize {
+			continue
+		}
+		dataOffset := pkt.Offset + ch10PrimaryHeaderSize
+		if dataOffset > size {
+			continue
+		}
+		maxAvail := size - dataOffset
+		if maxAvail < 0 {
+			maxAvail = 0
+		}
+		dataLenFromPacket := totalLen - ch10PrimaryHeaderSize
+		if dataLenFromPacket < 0 {
+			dataLenFromPacket = 0
+		}
+		if dataLenFromPacket > maxAvail {
+			dataLenFromPacket = maxAvail
+		}
+
+		calcFull, err := ch10.NewDataChecksum(ctx.Profile)
+		if err != nil {
+			f.Close()
+			diag.Severity = ERROR
+			diag.Message = "cannot init data checksum"
+			return diag, false, err
+		}
+		var calcStored *ch10.DataChecksum
+		remainingStored := int64(storedDataLen)
+		storedValid := remainingStored <= dataLenFromPacket
+		if storedValid {
+			calcStored, err = ch10.NewDataChecksum(ctx.Profile)
+			if err != nil {
+				f.Close()
+				diag.Severity = ERROR
+				diag.Message = "cannot init data checksum"
+				return diag, false, err
+			}
+		}
+
+		remainingFull := dataLenFromPacket
+		offset := dataOffset
+		for remainingFull > 0 {
+			chunk := int64(len(buf))
+			if remainingFull < chunk {
+				chunk = remainingFull
+			}
+			if chunk <= 0 {
+				break
+			}
+			n, err := f.ReadAt(buf[:int(chunk)], offset)
+			if err != nil && err != io.EOF {
+				f.Close()
+				diag.Severity = ERROR
+				diag.Message = fmt.Sprintf("read payload at offset %d failed", offset)
+				return diag, false, err
+			}
+			if n == 0 {
+				break
+			}
+			calcFull.Write(buf[:n])
+			if calcStored != nil && remainingStored > 0 {
+				portion := n
+				if int64(portion) > remainingStored {
+					portion = int(remainingStored)
+				}
+				if portion > 0 {
+					calcStored.Write(buf[:portion])
+					remainingStored -= int64(portion)
+				}
+			}
+			remainingFull -= int64(n)
+			offset += int64(n)
+			if int64(n) < chunk {
+				break
+			}
+		}
+		if calcStored != nil && remainingStored > 0 {
+			storedValid = false
+		}
+
+		crcFull := calcFull.Sum16()
+		var crcStored uint16
+		if calcStored != nil && storedValid {
+			crcStored = calcStored.Sum16()
+		}
+
+		storedMatches := storedValid && crcStored == storedChecksum
+		fullMatches := crcFull == storedChecksum
+
+		targetDataLen := uint32(dataLenFromPacket)
+		switch {
+		case storedMatches:
+			targetDataLen = storedDataLen
+		case fullMatches:
+			targetDataLen = uint32(dataLenFromPacket)
+		default:
+			targetDataLen = uint32(dataLenFromPacket)
+		}
+		targetPacketLen := targetDataLen + uint32(ch10PrimaryHeaderSize) - 4
+
+		packetChanged := false
+		if storedDataLen != targetDataLen {
+			var out [4]byte
+			binary.BigEndian.PutUint32(out[:], targetDataLen)
+			edits = append(edits, ch10.PatchEdit{Offset: pkt.Offset + 8, Data: out[:]})
+			packetChanged = true
+		}
+		if storedPacketLen != targetPacketLen {
+			var out [4]byte
+			binary.BigEndian.PutUint32(out[:], targetPacketLen)
+			edits = append(edits, ch10.PatchEdit{Offset: pkt.Offset + 4, Data: out[:]})
+			packetChanged = true
+		}
+		if packetChanged {
+			fixed++
+		}
+	}
+	f.Close()
+
+	if len(edits) == 0 {
+		diag.Message = "packet/data lengths verified"
+		return diag, false, nil
+	}
+	if err := ch10.ApplyPatch(ctx.InputFile, edits); err != nil {
+		diag.Severity = ERROR
+		diag.Message = "failed to update length fields"
+		return diag, false, err
+	}
+	diag.Message = fmt.Sprintf("updated length fields in %d packets", fixed)
+	diag.FixSuggested = true
+	return diag, true, nil
 }
 
 func RemapChannelIds(ctx *Context, rule Rule) (Diagnostic, bool, error) {


### PR DESCRIPTION
## Summary
- implement profile-aware header and payload checksum helpers in the parser package
- add an in-place patch utility for fixed-length updates
- update FixHeaderChecksum, FixDataChecksumOrTrailer, and FixLengths to recompute values and apply patches automatically

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68cdaee090c08328b0e05b498f09fbad