### PR TITLE
Implement time correlation and diagnostics controls

### DIFF
--- a/cmd/ch10ctl/main.go
+++ b/cmd/ch10ctl/main.go
@@ -53,6 +53,7 @@ func validateCmd(args []string) {
 	rulesPath := fs.String("rules", "", "rulepack.json")
 	outDiag := fs.String("out", "diagnostics.jsonl", "diagnostics output")
 	outAcc := fs.String("acceptance", "acceptance_report.json", "acceptance json")
+	includeTimestamps := fs.Bool("diag-include-timestamps", true, "include timestamp metadata in diagnostics output")
 	fs.Parse(args)
 
 	if *in == "" || *rulesPath == "" {
@@ -67,6 +68,7 @@ func validateCmd(args []string) {
 	}
 	engine := rules.NewEngine(rp)
 	engine.RegisterBuiltins()
+	engine.SetConfigValue("diag.include_timestamps", *includeTimestamps)
 
 	ctx := &rules.Context{InputFile: *in, TMATSFile: *tmats, Profile: *profile}
 	diags, err := engine.Eval(ctx)

--- a/internal/ch10/parser_test.go
+++ b/internal/ch10/parser_test.go
@@ -156,12 +156,16 @@ func TestReaderNextTimeStamp(t *testing.T) {
 	defer reader.Close()
 
 	expected := []struct {
-		hasSec bool
-		ts     int64
+		hasSec   bool
+		secBytes bool
+		secValid bool
+		ts       int64
+		source   TimestampSource
+		isTime   bool
 	}{
-		{hasSec: true, ts: 1_234_567},
-		{hasSec: false, ts: -1},
-		{hasSec: true, ts: -1},
+		{hasSec: true, secBytes: true, secValid: true, ts: 1_234_567, source: TimestampSourceTimePacket, isTime: true},
+		{hasSec: false, secBytes: false, secValid: false, ts: -1, source: TimestampSourceUnknown, isTime: true},
+		{hasSec: true, secBytes: true, secValid: false, ts: -1, source: TimestampSourceUnknown, isTime: true},
 	}
 
 	for i, want := range expected {
@@ -172,8 +176,20 @@ func TestReaderNextTimeStamp(t *testing.T) {
 		if idx.HasSecHdr != want.hasSec {
 			t.Fatalf("packet %d HasSecHdr = %v, want %v", i, idx.HasSecHdr, want.hasSec)
 		}
+		if idx.SecHdrBytes != want.secBytes {
+			t.Fatalf("packet %d SecHdrBytes = %v, want %v", i, idx.SecHdrBytes, want.secBytes)
+		}
+		if idx.SecHdrValid != want.secValid {
+			t.Fatalf("packet %d SecHdrValid = %v, want %v", i, idx.SecHdrValid, want.secValid)
+		}
 		if idx.TimeStampUs != want.ts {
 			t.Fatalf("packet %d TimeStampUs = %d, want %d", i, idx.TimeStampUs, want.ts)
+		}
+		if idx.Source != want.source {
+			t.Fatalf("packet %d Source = %q, want %q", i, idx.Source, want.source)
+		}
+		if idx.IsTimePacket != want.isTime {
+			t.Fatalf("packet %d IsTimePacket = %v, want %v", i, idx.IsTimePacket, want.isTime)
 		}
 	}
 
@@ -188,6 +204,217 @@ func TestReaderNextTimeStamp(t *testing.T) {
 	for i, pkt := range idx.Packets {
 		if pkt.TimeStampUs != expected[i].ts {
 			t.Fatalf("index packet %d TimeStampUs = %d, want %d", i, pkt.TimeStampUs, expected[i].ts)
+		}
+		if pkt.Source != expected[i].source {
+			t.Fatalf("index packet %d Source = %q, want %q", i, pkt.Source, expected[i].source)
+		}
+	}
+}
+
+func TestReaderTimeRefAndIPTS(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "ch10-ts-*.bin")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	defer tmp.Close()
+
+	timeSec := make([]byte, secondaryHeaderSize)
+	binary.BigEndian.PutUint16(timeSec[0:2], 0)
+	binary.BigEndian.PutUint16(timeSec[2:4], 0x007b)
+	binary.BigEndian.PutUint16(timeSec[4:6], 0x11d7)
+	writeTestPacket(t, tmp, 0x0000, packetFlagSecondaryHdr|timeFormatIRIG106, timeSec, nil)
+
+	dynSec := make([]byte, secondaryHeaderSize)
+	binary.BigEndian.PutUint16(dynSec[0:2], 0)
+	binary.BigEndian.PutUint16(dynSec[2:4], 0x007b)
+	binary.BigEndian.PutUint16(dynSec[4:6], 0x15bf)
+	writeTestPacket(t, tmp, 0x0011, packetFlagSecondaryHdr|timeFormatIRIG106, dynSec, nil)
+
+	iptsPayload := make([]byte, 8)
+	binary.BigEndian.PutUint64(iptsPayload, 200)
+	writeTestPacket(t, tmp, 0x0011, 0x00, nil, iptsPayload)
+
+	if err := tmp.Sync(); err != nil {
+		t.Fatalf("sync temp file failed: %v", err)
+	}
+
+	reader, err := NewReader(tmp.Name())
+	if err != nil {
+		t.Fatalf("NewReader failed: %v", err)
+	}
+	defer reader.Close()
+
+	_, first, err := reader.Next()
+	if err != nil {
+		t.Fatalf("first Next failed: %v", err)
+	}
+	if !first.IsTimePacket || first.Source != TimestampSourceTimePacket {
+		t.Fatalf("first packet source = %q, IsTimePacket=%v", first.Source, first.IsTimePacket)
+	}
+	if first.TimeStampUs != 1_234_567 {
+		t.Fatalf("first timestamp = %d, want 1234567", first.TimeStampUs)
+	}
+
+	_, second, err := reader.Next()
+	if err != nil {
+		t.Fatalf("second Next failed: %v", err)
+	}
+	if second.Source != TimestampSourceSecondaryHeader {
+		t.Fatalf("second packet source = %q, want secondary header", second.Source)
+	}
+	if second.TimeStampUs != 1_235_567 {
+		t.Fatalf("second timestamp = %d, want 1235567", second.TimeStampUs)
+	}
+
+	_, third, err := reader.Next()
+	if err != nil {
+		t.Fatalf("third Next failed: %v", err)
+	}
+	if third.Source != TimestampSourceIPTS {
+		t.Fatalf("third packet source = %q, want ipts", third.Source)
+	}
+	if third.TimeStampUs != 1_234_767 {
+		t.Fatalf("third timestamp = %d, want 1234767", third.TimeStampUs)
+	}
+
+	idx := reader.Index()
+	if !idx.TimeSeenBeforeDynamic {
+		t.Fatalf("TimeSeenBeforeDynamic = false, want true")
+	}
+	if !idx.HasTimePacket {
+		t.Fatalf("HasTimePacket = false, want true")
+	}
+	if len(idx.Packets) != 3 {
+		t.Fatalf("index packets = %d, want 3", len(idx.Packets))
+	}
+	if idx.Packets[2].Source != TimestampSourceIPTS {
+		t.Fatalf("index third source = %q, want ipts", idx.Packets[2].Source)
+	}
+}
+
+func TestReaderTimeSeenBeforeDynamic(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "ch10-order-*.bin")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	defer tmp.Close()
+
+	ieeeSec := make([]byte, secondaryHeaderSize)
+	binary.BigEndian.PutUint32(ieeeSec[0:4], 500_000_000)
+	binary.BigEndian.PutUint32(ieeeSec[4:8], 0)
+	writeTestPacket(t, tmp, 0x0011, packetFlagSecondaryHdr|timeFormatIEEE1588, ieeeSec, nil)
+
+	iptsEarly := make([]byte, 8)
+	binary.BigEndian.PutUint64(iptsEarly, 100)
+	writeTestPacket(t, tmp, 0x0011, 0x00, nil, iptsEarly)
+
+	timeSec := make([]byte, secondaryHeaderSize)
+	binary.BigEndian.PutUint16(timeSec[0:2], 0)
+	binary.BigEndian.PutUint16(timeSec[2:4], 0x007b)
+	binary.BigEndian.PutUint16(timeSec[4:6], 0x11d7)
+	writeTestPacket(t, tmp, 0x0000, packetFlagSecondaryHdr|timeFormatIRIG106, timeSec, nil)
+
+	iptsLate := make([]byte, 8)
+	binary.BigEndian.PutUint64(iptsLate, 300)
+	writeTestPacket(t, tmp, 0x0011, 0x00, nil, iptsLate)
+
+	if err := tmp.Sync(); err != nil {
+		t.Fatalf("sync temp file failed: %v", err)
+	}
+
+	reader, err := NewReader(tmp.Name())
+	if err != nil {
+		t.Fatalf("NewReader failed: %v", err)
+	}
+	defer reader.Close()
+
+	_, first, err := reader.Next()
+	if err != nil {
+		t.Fatalf("first Next failed: %v", err)
+	}
+	if first.Source != TimestampSourceSecondaryHeader {
+		t.Fatalf("first packet source = %q, want secondary header", first.Source)
+	}
+	if first.TimeStampUs != 500_000 {
+		t.Fatalf("first timestamp = %d, want 500000", first.TimeStampUs)
+	}
+
+	_, second, err := reader.Next()
+	if err != nil {
+		t.Fatalf("second Next failed: %v", err)
+	}
+	if second.TimeStampUs != -1 {
+		t.Fatalf("second timestamp = %d, want -1", second.TimeStampUs)
+	}
+	if second.Source != TimestampSourceUnknown {
+		t.Fatalf("second source = %q, want unknown", second.Source)
+	}
+
+	_, third, err := reader.Next()
+	if err != nil {
+		t.Fatalf("third Next failed: %v", err)
+	}
+	if third.Source != TimestampSourceTimePacket {
+		t.Fatalf("third source = %q, want time packet", third.Source)
+	}
+
+	_, fourth, err := reader.Next()
+	if err != nil {
+		t.Fatalf("fourth Next failed: %v", err)
+	}
+	if fourth.Source != TimestampSourceIPTS {
+		t.Fatalf("fourth source = %q, want ipts", fourth.Source)
+	}
+	if fourth.TimeStampUs != 1_234_867 {
+		t.Fatalf("fourth timestamp = %d, want 1234867", fourth.TimeStampUs)
+	}
+
+	idx := reader.Index()
+	if idx.TimeSeenBeforeDynamic {
+		t.Fatalf("TimeSeenBeforeDynamic = true, want false")
+	}
+	if !idx.HasTimePacket {
+		t.Fatalf("HasTimePacket = false, want true")
+	}
+	if len(idx.Packets) != 4 {
+		t.Fatalf("index packets = %d, want 4", len(idx.Packets))
+	}
+	if idx.Packets[1].TimeStampUs != -1 {
+		t.Fatalf("index second timestamp = %d, want -1", idx.Packets[1].TimeStampUs)
+	}
+	if idx.Packets[3].Source != TimestampSourceIPTS {
+		t.Fatalf("index fourth source = %q, want ipts", idx.Packets[3].Source)
+	}
+}
+
+func writeTestPacket(t *testing.T, f *os.File, dataType uint16, flags uint8, secHdr, payload []byte) {
+	t.Helper()
+	totalLen := primaryHeaderSize + len(secHdr) + len(payload)
+	packetLen := uint32(totalLen - 4)
+	header := make([]byte, primaryHeaderSize)
+	binary.BigEndian.PutUint16(header[0:2], syncPattern)
+	binary.BigEndian.PutUint16(header[2:4], 0x0001)
+	binary.BigEndian.PutUint32(header[4:8], packetLen)
+	binary.BigEndian.PutUint32(header[8:12], uint32(len(secHdr)+len(payload)))
+	binary.BigEndian.PutUint16(header[12:14], dataType)
+	header[14] = 0
+	header[15] = flags
+	if _, err := f.Write(header); err != nil {
+		t.Fatalf("write header failed: %v", err)
+	}
+	if len(secHdr) > 0 {
+		if len(secHdr) < secondaryHeaderSize {
+			padded := make([]byte, secondaryHeaderSize)
+			copy(padded, secHdr)
+			secHdr = padded
+		}
+		if _, err := f.Write(secHdr); err != nil {
+			t.Fatalf("write secondary header failed: %v", err)
+		}
+	}
+	if len(payload) > 0 {
+		if _, err := f.Write(payload); err != nil {
+			t.Fatalf("write payload failed: %v", err)
 		}
 	}
 }

--- a/internal/ch10/types.go
+++ b/internal/ch10/types.go
@@ -18,6 +18,15 @@ type SecondaryHeader struct {
 	TimeStampUs int64
 }
 
+type TimestampSource string
+
+const (
+	TimestampSourceUnknown         TimestampSource = ""
+	TimestampSourceSecondaryHeader TimestampSource = "secondary_header"
+	TimestampSourceTimePacket      TimestampSource = "time_packet"
+	TimestampSourceIPTS            TimestampSource = "ipts"
+)
+
 type PacketIndex struct {
 	Offset       int64
 	ChannelID    uint16
@@ -27,10 +36,17 @@ type PacketIndex struct {
 	PacketLength uint32
 	DataLength   uint32
 	HasSecHdr    bool
+	SecHdrValid  bool
+	SecHdrBytes  bool
+	TimeFormat   uint8
 	HasTrailer   bool
 	TimeStampUs  int64
+	Source       TimestampSource
+	IsTimePacket bool
 }
 
 type FileIndex struct {
-	Packets []PacketIndex
+	Packets               []PacketIndex
+	HasTimePacket         bool
+	TimeSeenBeforeDynamic bool
 }

--- a/internal/rules/builtin_time_test.go
+++ b/internal/rules/builtin_time_test.go
@@ -1,0 +1,169 @@
+package rules
+
+import (
+	"testing"
+
+	"example.com/ch10gate/internal/ch10"
+)
+
+func TestEnsureTimePacketMissingTime(t *testing.T) {
+	ctx := &Context{InputFile: "file.ch10", Index: &ch10.FileIndex{Packets: []ch10.PacketIndex{{}}}}
+	rule := Rule{RuleId: "RP-0009", Refs: []string{"ref"}}
+	diag, applied, err := EnsureTimePacket(ctx, rule)
+	if err != nil {
+		t.Fatalf("EnsureTimePacket returned error: %v", err)
+	}
+	if applied {
+		t.Fatalf("EnsureTimePacket applied fix unexpectedly")
+	}
+	if diag.Severity != ERROR {
+		t.Fatalf("severity = %s, want ERROR", diag.Severity)
+	}
+	if diag.Message != "no time packets detected" {
+		t.Fatalf("message = %q, want 'no time packets detected'", diag.Message)
+	}
+	if diag.TimestampUs != nil || diag.TimestampSource != nil {
+		t.Fatalf("expected nil timestamp fields, got %v/%v", diag.TimestampUs, diag.TimestampSource)
+	}
+}
+
+func TestEnsureTimePacketWarnsWhenDynamicBeforeTime(t *testing.T) {
+	timePkt := ch10.PacketIndex{IsTimePacket: true, TimeStampUs: 1_000_000, Source: ch10.TimestampSourceTimePacket, ChannelID: 10, Offset: 0x40}
+	dynPkt := ch10.PacketIndex{HasSecHdr: true, SecHdrBytes: true, SecHdrValid: true, TimeStampUs: 500_000, Source: ch10.TimestampSourceSecondaryHeader, ChannelID: 2, Offset: 0x20}
+	ctx := &Context{
+		InputFile: "file.ch10",
+		Index: &ch10.FileIndex{
+			HasTimePacket:         true,
+			TimeSeenBeforeDynamic: false,
+			Packets:               []ch10.PacketIndex{dynPkt, timePkt},
+		},
+	}
+	rule := Rule{RuleId: "RP-0009"}
+	diag, applied, err := EnsureTimePacket(ctx, rule)
+	if err != nil {
+		t.Fatalf("EnsureTimePacket returned error: %v", err)
+	}
+	if applied {
+		t.Fatalf("EnsureTimePacket applied fix unexpectedly")
+	}
+	if diag.Severity != WARN {
+		t.Fatalf("severity = %s, want WARN", diag.Severity)
+	}
+	if diag.PacketIndex != 0 {
+		t.Fatalf("PacketIndex = %d, want 0", diag.PacketIndex)
+	}
+	if diag.ChannelId != int(dynPkt.ChannelID) {
+		t.Fatalf("ChannelId = %d, want %d", diag.ChannelId, dynPkt.ChannelID)
+	}
+	if diag.TimestampUs == nil || *diag.TimestampUs != timePkt.TimeStampUs {
+		t.Fatalf("timestamp pointer incorrect: %v", diag.TimestampUs)
+	}
+	if diag.TimestampSource == nil || *diag.TimestampSource != string(timePkt.Source) {
+		t.Fatalf("timestamp source incorrect: %v", diag.TimestampSource)
+	}
+}
+
+func TestEnsureTimePacketReportsMissingSecHeader(t *testing.T) {
+	timePkt := ch10.PacketIndex{IsTimePacket: true, TimeStampUs: 1_000_000, Source: ch10.TimestampSourceTimePacket}
+	badDyn := ch10.PacketIndex{HasSecHdr: true, SecHdrBytes: false, ChannelID: 3, Offset: 0x60}
+	ctx := &Context{
+		InputFile: "file.ch10",
+		Index: &ch10.FileIndex{
+			HasTimePacket:         true,
+			TimeSeenBeforeDynamic: true,
+			Packets:               []ch10.PacketIndex{timePkt, badDyn},
+		},
+	}
+	diag, applied, err := EnsureTimePacket(ctx, Rule{RuleId: "RP-0009"})
+	if err != nil {
+		t.Fatalf("EnsureTimePacket returned error: %v", err)
+	}
+	if applied {
+		t.Fatalf("EnsureTimePacket applied fix unexpectedly")
+	}
+	if diag.Severity != ERROR {
+		t.Fatalf("severity = %s, want ERROR", diag.Severity)
+	}
+	if diag.PacketIndex != 1 {
+		t.Fatalf("PacketIndex = %d, want 1", diag.PacketIndex)
+	}
+	if diag.Message != "secondary header flag set but bytes missing" {
+		t.Fatalf("message = %q, want missing secondary header message", diag.Message)
+	}
+}
+
+func TestEnsureTimePacketInfo(t *testing.T) {
+	timePkt := ch10.PacketIndex{IsTimePacket: true, TimeStampUs: 1_234_567, Source: ch10.TimestampSourceTimePacket, ChannelID: 1, Offset: 0x100}
+	ctx := &Context{
+		InputFile: "file.ch10",
+		Index: &ch10.FileIndex{
+			HasTimePacket:         true,
+			TimeSeenBeforeDynamic: true,
+			Packets:               []ch10.PacketIndex{timePkt},
+		},
+	}
+	diag, applied, err := EnsureTimePacket(ctx, Rule{RuleId: "RP-0009"})
+	if err != nil {
+		t.Fatalf("EnsureTimePacket returned error: %v", err)
+	}
+	if applied {
+		t.Fatalf("EnsureTimePacket applied fix unexpectedly")
+	}
+	if diag.Severity != INFO {
+		t.Fatalf("severity = %s, want INFO", diag.Severity)
+	}
+	if diag.Message != "time packet present before first dynamic packet" {
+		t.Fatalf("message = %q, want success message", diag.Message)
+	}
+	if diag.TimestampUs == nil || *diag.TimestampUs != timePkt.TimeStampUs {
+		t.Fatalf("timestamp pointer incorrect: %v", diag.TimestampUs)
+	}
+	if diag.TimestampSource == nil || *diag.TimestampSource != string(timePkt.Source) {
+		t.Fatalf("timestamp source incorrect: %v", diag.TimestampSource)
+	}
+}
+
+func TestSyncSecondaryTimeFmtCases(t *testing.T) {
+	ctxEmpty := &Context{InputFile: "file.ch10", Index: &ch10.FileIndex{Packets: []ch10.PacketIndex{{}}}}
+	diag, _, err := SyncSecondaryTimeFmt(ctxEmpty, Rule{RuleId: "RP-0019"})
+	if err != nil {
+		t.Fatalf("SyncSecondaryTimeFmt returned error: %v", err)
+	}
+	if diag.Severity != INFO || diag.Message != "no packets with secondary header timestamps" {
+		t.Fatalf("unexpected diag for empty index: %+v", diag)
+	}
+
+	pkt1 := ch10.PacketIndex{HasSecHdr: true, SecHdrBytes: true, SecHdrValid: true, TimeFormat: 0x00, TimeStampUs: 1_000_000, Source: ch10.TimestampSourceSecondaryHeader, ChannelID: 1, Offset: 0x20}
+	pkt2 := ch10.PacketIndex{HasSecHdr: true, SecHdrBytes: true, SecHdrValid: true, TimeFormat: 0x00, TimeStampUs: 1_000_100, Source: ch10.TimestampSourceSecondaryHeader, ChannelID: 2, Offset: 0x40}
+	ctxConsistent := &Context{InputFile: "file.ch10", Index: &ch10.FileIndex{Packets: []ch10.PacketIndex{pkt1, pkt2}}}
+	diag, _, err = SyncSecondaryTimeFmt(ctxConsistent, Rule{RuleId: "RP-0019"})
+	if err != nil {
+		t.Fatalf("SyncSecondaryTimeFmt consistent returned error: %v", err)
+	}
+	if diag.Severity != INFO {
+		t.Fatalf("severity = %s, want INFO", diag.Severity)
+	}
+	if diag.Message != "secondary header time format consistent (0x0)" {
+		t.Fatalf("message = %q, want consistent message", diag.Message)
+	}
+	if diag.TimestampUs == nil || *diag.TimestampUs != pkt1.TimeStampUs {
+		t.Fatalf("timestamp pointer incorrect: %v", diag.TimestampUs)
+	}
+
+	pkt3 := ch10.PacketIndex{HasSecHdr: true, SecHdrBytes: true, SecHdrValid: true, TimeFormat: 0x04, TimeStampUs: 2_000_000, Source: ch10.TimestampSourceSecondaryHeader, ChannelID: 3, Offset: 0x60}
+	ctxMismatch := &Context{InputFile: "file.ch10", Index: &ch10.FileIndex{Packets: []ch10.PacketIndex{pkt1, pkt3}}}
+	diag, _, err = SyncSecondaryTimeFmt(ctxMismatch, Rule{RuleId: "RP-0019"})
+	if err != nil {
+		t.Fatalf("SyncSecondaryTimeFmt mismatch returned error: %v", err)
+	}
+	if diag.Severity != WARN {
+		t.Fatalf("severity = %s, want WARN", diag.Severity)
+	}
+	if diag.PacketIndex != 1 {
+		t.Fatalf("PacketIndex = %d, want 1", diag.PacketIndex)
+	}
+	wantMsg := "secondary header time formats inconsistent: 0x4 vs 0x0"
+	if diag.Message != wantMsg {
+		t.Fatalf("message = %q, want %q", diag.Message, wantMsg)
+	}
+}

--- a/internal/rules/engine_test.go
+++ b/internal/rules/engine_test.go
@@ -10,17 +10,19 @@ import (
 )
 
 func TestWriteDiagnosticsNDJSONIncludesTimestamp(t *testing.T) {
-	eng := &Engine{}
+	eng := NewEngine(RulePack{})
 	withTs := int64(123456)
+	src := "secondary_header"
 	eng.diagnostics = []Diagnostic{
 		{
-			Ts:          time.Unix(0, 0),
-			File:        "input.ch10",
-			RuleId:      "RP-TEST-1",
-			Severity:    INFO,
-			Message:     "with timestamp",
-			Refs:        []string{"ref"},
-			TimestampUs: &withTs,
+			Ts:              time.Unix(0, 0),
+			File:            "input.ch10",
+			RuleId:          "RP-TEST-1",
+			Severity:        INFO,
+			Message:         "with timestamp",
+			Refs:            []string{"ref"},
+			TimestampUs:     &withTs,
+			TimestampSource: &src,
 		},
 		{
 			Ts:       time.Unix(1, 0),
@@ -56,6 +58,11 @@ func TestWriteDiagnosticsNDJSONIncludesTimestamp(t *testing.T) {
 	} else if num, ok := v.(float64); !ok || int64(num) != withTs {
 		t.Fatalf("timestamp_us = %v, want %d", v, withTs)
 	}
+	if v, ok := first["timestamp_source"]; !ok {
+		t.Fatalf("timestamp_source missing from first diagnostic")
+	} else if str, ok := v.(string); !ok || str != src {
+		t.Fatalf("timestamp_source = %v, want %s", v, src)
+	}
 
 	var second map[string]any
 	if err := json.Unmarshal(lines[1], &second); err != nil {
@@ -65,6 +72,54 @@ func TestWriteDiagnosticsNDJSONIncludesTimestamp(t *testing.T) {
 		t.Fatalf("timestamp_us missing from second diagnostic")
 	} else if v != nil {
 		t.Fatalf("timestamp_us expected nil, got %v", v)
+	}
+	if v, ok := second["timestamp_source"]; !ok {
+		t.Fatalf("timestamp_source missing from second diagnostic")
+	} else if v != nil {
+		t.Fatalf("timestamp_source expected nil, got %v", v)
+	}
+}
+
+func TestWriteDiagnosticsNDJSONOmitsTimestampWhenDisabled(t *testing.T) {
+	eng := NewEngine(RulePack{})
+	ts := int64(42)
+	src := "secondary_header"
+	eng.diagnostics = []Diagnostic{
+		{
+			Ts:              time.Unix(0, 0),
+			File:            "input.ch10",
+			RuleId:          "RP-TEST-3",
+			Severity:        WARN,
+			Message:         "timestamp disabled",
+			Refs:            []string{"ref"},
+			TimestampUs:     &ts,
+			TimestampSource: &src,
+		},
+	}
+	eng.SetConfigValue("diag.include_timestamps", false)
+
+	outPath := filepath.Join(t.TempDir(), "diagnostics.jsonl")
+	if err := eng.WriteDiagnosticsNDJSON(outPath); err != nil {
+		t.Fatalf("WriteDiagnosticsNDJSON failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	lines := bytesTrimSplit(data)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(lines))
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(lines[0], &obj); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if _, ok := obj["timestamp_us"]; ok {
+		t.Fatalf("timestamp_us present when disabled: %v", obj["timestamp_us"])
+	}
+	if _, ok := obj["timestamp_source"]; ok {
+		t.Fatalf("timestamp_source present when disabled: %v", obj["timestamp_source"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- update the Chapter 10 reader to mark time packets, carry timestamp sources, and correlate IPTS payloads with the most recent time reference
- expand diagnostics output with a timestamp_source field and add a config switch, wiring the flag into the CLI
- implement RP-0009/RP-0019 logic with new tests covering time ordering, secondary header validation, and timestamp serialization

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68cdbce56f788328be91c8557ea725c7