### PR TITLE
Implement Ethernet autofixes and tests

### DIFF
--- a/internal/ch10/types.go
+++ b/internal/ch10/types.go
@@ -120,3 +120,29 @@ type PCMInfo struct {
 	ReservedNonZero bool
 	ParseError      string
 }
+
+type EthernetFrameView struct {
+	Index       int
+	HasIPH      bool
+	IPHOffset   int
+	FrameOffset int
+	FrameLength int
+	FrameIDWord uint32
+}
+
+type A664MessageView struct {
+	Index            int
+	IPHOffset        int
+	IPHLength        int
+	IPDHWord1        uint32
+	PayloadLength    int
+	DataOffset       int
+	MessageLength    int
+	IPv4Offset       int
+	IPv4HeaderLength int
+	IPv4TotalLength  int
+	UDPOffset        int
+	UDPLength        uint16
+	UDPChecksum      uint16
+	Proto            uint8
+}

--- a/internal/eth/eth.go
+++ b/internal/eth/eth.go
@@ -1,0 +1,158 @@
+package eth
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrFrameTooShort   = errors.New("ethernet frame too short")
+	ErrIPv4Header      = errors.New("invalid ipv4 header")
+	ErrUnsupportedType = errors.New("unsupported ether type for length inference")
+	ErrUDPPacket       = errors.New("invalid udp segment")
+)
+
+// ParseEthernet parses an Ethernet II frame beginning at buf and returns
+// metadata about the frame. The returned frameLen is the number of bytes
+// comprising the captured frame (excluding any trailing data beyond the
+// frame). The parser currently supports Ethernet II frames with optional
+// 802.1Q VLAN tagging.
+func ParseEthernet(buf []byte) (hasVLAN bool, etherType uint16, l2HdrLen int, payloadOff int, frameLen int, err error) {
+	if len(buf) < 14 {
+		return false, 0, 0, 0, 0, ErrFrameTooShort
+	}
+	headerLen := 14
+	etherType = binary.BigEndian.Uint16(buf[12:14])
+	if etherType == 0x8100 {
+		if len(buf) < 18 {
+			return false, 0, 0, 0, 0, ErrFrameTooShort
+		}
+		hasVLAN = true
+		headerLen = 18
+		etherType = binary.BigEndian.Uint16(buf[16:18])
+	}
+	payloadOff = headerLen
+	l2HdrLen = headerLen
+
+	switch {
+	case etherType <= 1500:
+		payloadLen := int(etherType)
+		frameLen = headerLen + payloadLen
+	case etherType == 0x0800:
+		if len(buf) < headerLen+20 {
+			return hasVLAN, etherType, headerLen, payloadOff, 0, ErrFrameTooShort
+		}
+		_, totalLen, _, _, _, _, perr := ParseIPv4(buf[headerLen:])
+		if perr != nil {
+			return hasVLAN, etherType, headerLen, payloadOff, 0, perr
+		}
+		frameLen = headerLen + totalLen
+	default:
+		return hasVLAN, etherType, headerLen, payloadOff, 0, fmt.Errorf("%w: 0x%04X", ErrUnsupportedType, etherType)
+	}
+
+	if frameLen > len(buf) {
+		return hasVLAN, etherType, headerLen, payloadOff, 0, fmt.Errorf("frame length %d exceeds buffer (%d)", frameLen, len(buf))
+	}
+	return hasVLAN, etherType, headerLen, payloadOff, frameLen, nil
+}
+
+// ParseIPv4 parses an IPv4 header from buf and returns the header length, total
+// length, transport protocol, source/destination addresses, and the header
+// offset (which is always zero for the provided slice).
+func ParseIPv4(buf []byte) (ihl int, totalLen int, proto uint8, src, dst [4]byte, hdrOff int, err error) {
+	if len(buf) < 20 {
+		err = ErrIPv4Header
+		return
+	}
+	version := buf[0] >> 4
+	if version != 4 {
+		err = ErrIPv4Header
+		return
+	}
+	ihl = int(buf[0]&0x0F) * 4
+	if ihl < 20 || len(buf) < ihl {
+		err = ErrIPv4Header
+		return
+	}
+	totalLen = int(binary.BigEndian.Uint16(buf[2:4]))
+	if totalLen < ihl {
+		err = ErrIPv4Header
+		return
+	}
+	proto = buf[9]
+	copy(src[:], buf[12:16])
+	copy(dst[:], buf[16:20])
+	hdrOff = 0
+	return
+}
+
+// ParseUDP parses a UDP header from buf, where buf should start at the IPv4
+// header. The ipOff argument specifies the length of the IPv4 header. The
+// returned udpOff is the offset within buf to the UDP header.
+func ParseUDP(buf []byte, ipOff int) (srcPort, dstPort, length, checksum uint16, udpOff int, err error) {
+	if ipOff < 0 || len(buf) < ipOff+8 {
+		err = ErrUDPPacket
+		return
+	}
+	udpOff = ipOff
+	if len(buf) < udpOff+8 {
+		err = ErrUDPPacket
+		return
+	}
+	srcPort = binary.BigEndian.Uint16(buf[udpOff : udpOff+2])
+	dstPort = binary.BigEndian.Uint16(buf[udpOff+2 : udpOff+4])
+	length = binary.BigEndian.Uint16(buf[udpOff+4 : udpOff+6])
+	checksum = binary.BigEndian.Uint16(buf[udpOff+6 : udpOff+8])
+	return
+}
+
+// IPv4HeaderChecksum computes the RFC 791 header checksum for the provided
+// IPv4 header bytes. The caller must ensure the checksum field within the
+// header is zeroed prior to invoking this function.
+func IPv4HeaderChecksum(b []byte) uint16 {
+	var sum uint32
+	n := len(b)
+	for i := 0; i+1 < n; i += 2 {
+		word := binary.BigEndian.Uint16(b[i : i+2])
+		sum += uint32(word)
+	}
+	if n%2 == 1 {
+		sum += uint32(b[n-1]) << 8
+	}
+	for (sum >> 16) != 0 {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+	return ^uint16(sum & 0xFFFF)
+}
+
+// UDPChecksum computes the UDP checksum for an IPv4 packet using the provided
+// IPv4 header and UDP header+payload slice. The IPv4 header must contain at
+// least 20 bytes and the UDP slice must contain at least the 8-byte header.
+func UDPChecksum(ipHdr, udp []byte) uint16 {
+	if len(ipHdr) < 20 || len(udp) < 8 {
+		return 0
+	}
+	var sum uint32
+	pseudo := []byte{
+		ipHdr[12], ipHdr[13], ipHdr[14], ipHdr[15],
+		ipHdr[16], ipHdr[17], ipHdr[18], ipHdr[19],
+		0, ipHdr[9], byte(len(udp) >> 8), byte(len(udp)),
+	}
+	for i := 0; i < len(pseudo); i += 2 {
+		word := binary.BigEndian.Uint16(pseudo[i : i+2])
+		sum += uint32(word)
+	}
+	for i := 0; i+1 < len(udp); i += 2 {
+		word := binary.BigEndian.Uint16(udp[i : i+2])
+		sum += uint32(word)
+	}
+	if len(udp)%2 == 1 {
+		sum += uint32(udp[len(udp)-1]) << 8
+	}
+	for (sum >> 16) != 0 {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+	return ^uint16(sum & 0xFFFF)
+}

--- a/internal/rules/builtin_eth_test.go
+++ b/internal/rules/builtin_eth_test.go
@@ -1,0 +1,215 @@
+package rules
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"example.com/ch10gate/internal/ch10"
+	"example.com/ch10gate/internal/eth"
+)
+
+func writePrimaryHeader(t *testing.T, dataType uint16, dataLen int, flags uint8) []byte {
+	t.Helper()
+	total := ch10PrimaryHeaderSize + dataLen
+	hdr := make([]byte, ch10PrimaryHeaderSize)
+	binary.BigEndian.PutUint16(hdr[0:2], 0xEB25)
+	binary.BigEndian.PutUint16(hdr[2:4], 1)
+	binary.BigEndian.PutUint32(hdr[4:8], uint32(total-4))
+	binary.BigEndian.PutUint32(hdr[8:12], uint32(dataLen))
+	binary.BigEndian.PutUint16(hdr[12:14], dataType)
+	hdr[14] = 0
+	hdr[15] = flags
+	chk, err := ch10.ComputeHeaderChecksum("106-15", hdr)
+	if err != nil {
+		t.Fatalf("checksum: %v", err)
+	}
+	binary.BigEndian.PutUint16(hdr[16:18], chk)
+	return hdr
+}
+
+func TestAddEthIPHInsertsMissingHeader(t *testing.T) {
+	t.Parallel()
+	frame := make([]byte, 0, 64)
+	// Ethernet header
+	frame = append(frame, []byte{
+		0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+		0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+		0x08, 0x00,
+	}...)
+	// IPv4 header (incorrect checksum will be recomputed later if needed)
+	ip := make([]byte, 20)
+	ip[0] = 0x45
+	ip[1] = 0
+	binary.BigEndian.PutUint16(ip[2:4], 32)
+	ip[6] = 0
+	ip[7] = 0
+	ip[8] = 64
+	ip[9] = 17
+	copy(ip[12:16], []byte{192, 0, 2, 1})
+	copy(ip[16:20], []byte{198, 51, 100, 2})
+	ip[10] = 0
+	ip[11] = 0
+	csum := eth.IPv4HeaderChecksum(ip)
+	binary.BigEndian.PutUint16(ip[10:12], csum)
+	frame = append(frame, ip...)
+	udp := make([]byte, 8)
+	binary.BigEndian.PutUint16(udp[0:2], 0x1111)
+	binary.BigEndian.PutUint16(udp[2:4], 0x2222)
+	binary.BigEndian.PutUint16(udp[4:6], 12)
+	// leave checksum zero
+	frame = append(frame, udp...)
+	frame = append(frame, []byte{0xDE, 0xAD, 0xBE, 0xEF}...)
+
+	csdw := make([]byte, 4)
+	binary.BigEndian.PutUint32(csdw, 0x00000001)
+	body := append(csdw, frame...)
+
+	hdr := writePrimaryHeader(t, 0x50, len(body), 0)
+	fileData := append(hdr, body...)
+
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "eth_missing.ch10")
+	if err := os.WriteFile(inPath, fileData, 0644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	ctx := &Context{InputFile: inPath, Profile: "106-15"}
+	rule := Rule{RuleId: "RP-0015"}
+	diag, applied, err := AddEthIPH(ctx, rule)
+	if err != nil {
+		t.Fatalf("AddEthIPH error: %v", err)
+	}
+	if !applied || !diag.FixApplied {
+		t.Fatalf("expected fix applied, diag=%+v", diag)
+	}
+	outPath := inPath + ".fixed.ch10"
+	if diag.FixPatchId != filepath.Base(outPath) {
+		t.Fatalf("unexpected FixPatchId %q", diag.FixPatchId)
+	}
+	out, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read fixed: %v", err)
+	}
+	if len(out) <= len(fileData) {
+		t.Fatalf("expected larger file after insertion")
+	}
+	newDataLen := binary.BigEndian.Uint32(out[8:12])
+	if newDataLen != uint32(len(body)+12) {
+		t.Fatalf("unexpected data length %d", newDataLen)
+	}
+	newPacketLen := binary.BigEndian.Uint32(out[4:8])
+	if newPacketLen != uint32(ch10PrimaryHeaderSize+len(body)+12-4) {
+		t.Fatalf("unexpected packet length %d", newPacketLen)
+	}
+	// Verify inserted IPH
+	bodyStart := ch10PrimaryHeaderSize
+	iph := out[bodyStart+4 : bodyStart+16]
+	frameID := binary.BigEndian.Uint32(iph[8:12]) & 0x3FFF
+	if int(frameID) != len(frame) {
+		t.Fatalf("frame length mismatch: %d vs %d", frameID, len(frame))
+	}
+	// Ensure checksum updated
+	chk, err := ch10.ComputeHeaderChecksum("106-15", out[:ch10PrimaryHeaderSize])
+	if err != nil {
+		t.Fatalf("checksum compute: %v", err)
+	}
+	stored := binary.BigEndian.Uint16(out[16:18])
+	if chk != stored {
+		t.Fatalf("header checksum mismatch: got %04X want %04X", stored, chk)
+	}
+}
+
+func TestFixA664LensRepairsLengths(t *testing.T) {
+	t.Parallel()
+	payloadLen := 4
+	body := make([]byte, 0, 96)
+	csdw := uint32(0x00180001)
+	tmp := make([]byte, 4)
+	binary.BigEndian.PutUint32(tmp, csdw)
+	body = append(body, tmp...)
+	iph := make([]byte, 24)
+	word1 := uint32(payloadLen << 16)
+	binary.BigEndian.PutUint32(iph[8:12], word1)
+	copy(iph[12:16], []byte{0, 0, 0, 1})
+	copy(iph[16:20], []byte{0, 0, 0, 2})
+	copy(iph[20:24], []byte{0x12, 0x34, 0x56, 0x78})
+	body = append(body, iph...)
+	ip := make([]byte, 20)
+	ip[0] = 0x45
+	binary.BigEndian.PutUint16(ip[2:4], 64)
+	ip[8] = 64
+	ip[9] = 17
+	copy(ip[12:16], []byte{0, 0, 0, 1})
+	copy(ip[16:20], []byte{0, 0, 0, 2})
+	ip[10] = 0
+	ip[11] = 0
+	csum := eth.IPv4HeaderChecksum(ip)
+	binary.BigEndian.PutUint16(ip[10:12], csum)
+	body = append(body, ip...)
+	udp := make([]byte, 8)
+	binary.BigEndian.PutUint16(udp[0:2], 0x1234)
+	binary.BigEndian.PutUint16(udp[2:4], 0x5678)
+	binary.BigEndian.PutUint16(udp[4:6], 20)
+	binary.BigEndian.PutUint16(udp[6:8], 0xFFFF)
+	body = append(body, udp...)
+	body = append(body, []byte{0xCA, 0xFE, 0xBA, 0xBE}...)
+
+	hdr := writePrimaryHeader(t, 0x51, len(body), 0)
+	data := append(hdr, body...)
+
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "a664_bad.ch10")
+	if err := os.WriteFile(inPath, data, 0644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	ctx := &Context{InputFile: inPath, Profile: "106-15"}
+	rule := Rule{RuleId: "RP-0016"}
+	diag, applied, err := FixA664Lens(ctx, rule)
+	if err != nil {
+		t.Fatalf("FixA664Lens error: %v", err)
+	}
+	if !applied || !diag.FixApplied {
+		t.Fatalf("expected fix applied, diag=%+v", diag)
+	}
+
+	out, err := os.ReadFile(inPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	bodyStart := ch10PrimaryHeaderSize
+	// Skip CSDW and IPH
+	ipv4Offset := bodyStart + 4 + 24
+	udpOffset := ipv4Offset + 20
+	totalLen := binary.BigEndian.Uint16(out[ipv4Offset+2 : ipv4Offset+4])
+	if totalLen != uint16(20+8+payloadLen) {
+		t.Fatalf("unexpected ipv4 total length %d", totalLen)
+	}
+	udpLen := binary.BigEndian.Uint16(out[udpOffset+4 : udpOffset+6])
+	if udpLen != uint16(8+payloadLen) {
+		t.Fatalf("unexpected udp length %d", udpLen)
+	}
+	ipv4Hdr := make([]byte, 20)
+	copy(ipv4Hdr, out[ipv4Offset:ipv4Offset+20])
+	ipv4Hdr[10] = 0
+	ipv4Hdr[11] = 0
+	wantIPCS := eth.IPv4HeaderChecksum(ipv4Hdr)
+	gotIPCS := binary.BigEndian.Uint16(out[ipv4Offset+10 : ipv4Offset+12])
+	if wantIPCS != gotIPCS {
+		t.Fatalf("ipv4 checksum mismatch: got %04X want %04X", gotIPCS, wantIPCS)
+	}
+	udpSeg := make([]byte, 8+payloadLen)
+	copy(udpSeg, out[udpOffset:udpOffset+8+payloadLen])
+	udpSeg[6] = 0
+	udpSeg[7] = 0
+	wantUDPCS := eth.UDPChecksum(ipv4Hdr, udpSeg)
+	if wantUDPCS == 0 {
+		wantUDPCS = 0xFFFF
+	}
+	gotUDPCS := binary.BigEndian.Uint16(out[udpOffset+6 : udpOffset+8])
+	if gotUDPCS != wantUDPCS {
+		t.Fatalf("udp checksum mismatch: got %04X want %04X", gotUDPCS, wantUDPCS)
+	}
+}


### PR DESCRIPTION
## Summary
- add Ethernet parsing and checksum helpers plus packet rewrite support
- implement Ethernet Format 0 IPH insertion and Format 1 length reconciliation
- extend CLI autofix reporting and add unit tests covering the new rules

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68ce4e7cd0b883289d619a96cb9d2862