### PR TITLE
Add structural rewrite plan and time packet autofix

### DIFF
--- a/internal/rules/builtin_time_test.go
+++ b/internal/rules/builtin_time_test.go
@@ -1,65 +1,119 @@
 package rules
 
 import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"example.com/ch10gate/internal/ch10"
+	"example.com/ch10gate/internal/tmats"
 )
 
 func TestEnsureTimePacketMissingTime(t *testing.T) {
-	ctx := &Context{InputFile: "file.ch10", Index: &ch10.FileIndex{Packets: []ch10.PacketIndex{{}}}}
+	dir := t.TempDir()
+	ch10Path := filepath.Join(dir, "input.ch10")
+	writeChapter10File(t, ch10Path, buildPCMPacket(t, 2, 0))
+	tmatsPath := filepath.Join(dir, "input.tmats")
+	writeTMATSFile(t, tmatsPath)
+
+	ctx := &Context{InputFile: ch10Path, TMATSFile: tmatsPath, Profile: "106-15"}
 	rule := Rule{RuleId: "RP-0009", Refs: []string{"ref"}}
 	diag, applied, err := EnsureTimePacket(ctx, rule)
 	if err != nil {
 		t.Fatalf("EnsureTimePacket returned error: %v", err)
 	}
-	if applied {
-		t.Fatalf("EnsureTimePacket applied fix unexpectedly")
+	if !applied {
+		t.Fatalf("expected fix to be applied")
 	}
-	if diag.Severity != ERROR {
-		t.Fatalf("severity = %s, want ERROR", diag.Severity)
+	if diag.Severity != INFO {
+		t.Fatalf("severity = %s, want INFO", diag.Severity)
 	}
-	if diag.Message != "no time packets detected" {
-		t.Fatalf("message = %q, want 'no time packets detected'", diag.Message)
+	if !strings.Contains(diag.Message, "inserted time reference packet") {
+		t.Fatalf("message = %q, want insertion notice", diag.Message)
 	}
-	if diag.TimestampUs != nil || diag.TimestampSource != nil {
-		t.Fatalf("expected nil timestamp fields, got %v/%v", diag.TimestampUs, diag.TimestampSource)
+	if diag.TimestampSource == nil || *diag.TimestampSource != string(ch10.TimestampSourceTimePacket) {
+		t.Fatalf("timestamp source = %v, want time_packet", diag.TimestampSource)
+	}
+
+	outPath := ch10Path + ".fixed.ch10"
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("expected fixed Chapter 10 file: %v", err)
+	}
+
+	tmatsOut := tmatsPath + ".tmats.fixed"
+	if _, err := os.Stat(tmatsOut); err != nil {
+		t.Fatalf("expected fixed TMATS file: %v", err)
+	}
+	doc, err := tmats.Parse(tmatsOut)
+	if err != nil {
+		t.Fatalf("parse fixed TMATS: %v", err)
+	}
+	group := inferTMATSRecordGroup(doc)
+	if val, ok := doc.Get(fmt.Sprintf("%s\\RI3", group)); !ok || val != "MODIFIED" {
+		t.Fatalf("RI3 not updated, got %q", val)
+	}
+	if val, ok := doc.Get(fmt.Sprintf("%s\\RI6", group)); !ok || !strings.Contains(val, "Inserted time packet") {
+		t.Fatalf("RI6 detail missing, got %q", val)
+	}
+	foundComment := false
+	for _, c := range doc.Comments() {
+		if strings.Contains(c, rule.RuleId) {
+			foundComment = true
+			break
+		}
+	}
+	if !foundComment {
+		t.Fatalf("expected comment referencing rule id")
 	}
 }
 
-func TestEnsureTimePacketWarnsWhenDynamicBeforeTime(t *testing.T) {
-	timePkt := ch10.PacketIndex{IsTimePacket: true, TimeStampUs: 1_000_000, Source: ch10.TimestampSourceTimePacket, ChannelID: 10, Offset: 0x40}
-	dynPkt := ch10.PacketIndex{HasSecHdr: true, SecHdrBytes: true, SecHdrValid: true, TimeStampUs: 500_000, Source: ch10.TimestampSourceSecondaryHeader, ChannelID: 2, Offset: 0x20}
-	ctx := &Context{
-		InputFile: "file.ch10",
-		Index: &ch10.FileIndex{
-			HasTimePacket:         true,
-			TimeSeenBeforeDynamic: false,
-			Packets:               []ch10.PacketIndex{dynPkt, timePkt},
-		},
+func TestEnsureTimePacketFixesWhenDynamicBeforeTime(t *testing.T) {
+	dir := t.TempDir()
+	ch10Path := filepath.Join(dir, "input.ch10")
+	dynamic := buildPCMPacket(t, 3, 0)
+	timePkt, err := ch10.BuildTimePacket("106-15", 5, 0x00, 1_000_000)
+	if err != nil {
+		t.Fatalf("build time packet: %v", err)
 	}
+	writeChapter10File(t, ch10Path, dynamic, timePkt)
+	tmatsPath := filepath.Join(dir, "input.tmats")
+	writeTMATSFile(t, tmatsPath)
+
+	ctx := &Context{InputFile: ch10Path, TMATSFile: tmatsPath, Profile: "106-15"}
 	rule := Rule{RuleId: "RP-0009"}
 	diag, applied, err := EnsureTimePacket(ctx, rule)
 	if err != nil {
 		t.Fatalf("EnsureTimePacket returned error: %v", err)
 	}
-	if applied {
-		t.Fatalf("EnsureTimePacket applied fix unexpectedly")
-	}
-	if diag.Severity != WARN {
-		t.Fatalf("severity = %s, want WARN", diag.Severity)
+	if !applied {
+		t.Fatalf("expected fix to be applied")
 	}
 	if diag.PacketIndex != 0 {
 		t.Fatalf("PacketIndex = %d, want 0", diag.PacketIndex)
 	}
-	if diag.ChannelId != int(dynPkt.ChannelID) {
-		t.Fatalf("ChannelId = %d, want %d", diag.ChannelId, dynPkt.ChannelID)
+	if diag.ChannelId != 5 {
+		t.Fatalf("ChannelId = %d, want 5", diag.ChannelId)
 	}
-	if diag.TimestampUs == nil || *diag.TimestampUs != timePkt.TimeStampUs {
+	if diag.TimestampUs == nil || *diag.TimestampUs != 1_000_000 {
 		t.Fatalf("timestamp pointer incorrect: %v", diag.TimestampUs)
 	}
-	if diag.TimestampSource == nil || *diag.TimestampSource != string(timePkt.Source) {
-		t.Fatalf("timestamp source incorrect: %v", diag.TimestampSource)
+	if !strings.Contains(diag.Message, "time packet observed after dynamic data") {
+		t.Fatalf("message = %q, want reason for late time", diag.Message)
+	}
+
+	outPath := ch10Path + ".fixed.ch10"
+	reader, err := ch10.NewReader(outPath)
+	if err != nil {
+		t.Fatalf("open fixed file: %v", err)
+	}
+	defer reader.Close()
+	if _, idx, err := reader.Next(); err != nil {
+		t.Fatalf("reader.Next: %v", err)
+	} else if !idx.IsTimePacket {
+		t.Fatalf("first packet not time after fix: %+v", idx)
 	}
 }
 
@@ -68,6 +122,7 @@ func TestEnsureTimePacketReportsMissingSecHeader(t *testing.T) {
 	badDyn := ch10.PacketIndex{HasSecHdr: true, SecHdrBytes: false, ChannelID: 3, Offset: 0x60}
 	ctx := &Context{
 		InputFile: "file.ch10",
+		Profile:   "106-15",
 		Index: &ch10.FileIndex{
 			HasTimePacket:         true,
 			TimeSeenBeforeDynamic: true,
@@ -96,6 +151,7 @@ func TestEnsureTimePacketInfo(t *testing.T) {
 	timePkt := ch10.PacketIndex{IsTimePacket: true, TimeStampUs: 1_234_567, Source: ch10.TimestampSourceTimePacket, ChannelID: 1, Offset: 0x100}
 	ctx := &Context{
 		InputFile: "file.ch10",
+		Profile:   "106-15",
 		Index: &ch10.FileIndex{
 			HasTimePacket:         true,
 			TimeSeenBeforeDynamic: true,
@@ -165,5 +221,49 @@ func TestSyncSecondaryTimeFmtCases(t *testing.T) {
 	wantMsg := "secondary header time formats inconsistent: 0x4 vs 0x0"
 	if diag.Message != wantMsg {
 		t.Fatalf("message = %q, want %q", diag.Message, wantMsg)
+	}
+}
+
+func buildPCMPacket(t *testing.T, channel uint16, seq uint8) []byte {
+	t.Helper()
+	header := make([]byte, ch10PrimaryHeaderSize)
+	binary.BigEndian.PutUint16(header[0:2], 0xEB25)
+	binary.BigEndian.PutUint16(header[2:4], channel)
+	payloadLen := 12
+	binary.BigEndian.PutUint32(header[4:8], uint32(ch10PrimaryHeaderSize+payloadLen-4))
+	binary.BigEndian.PutUint32(header[8:12], uint32(payloadLen))
+	binary.BigEndian.PutUint16(header[12:14], 0x08)
+	header[14] = seq
+	header[15] = 0
+	header[16] = 0
+	header[17] = 0
+	chk, err := ch10.ComputeHeaderChecksum("106-15", header)
+	if err != nil {
+		t.Fatalf("ComputeHeaderChecksum: %v", err)
+	}
+	binary.BigEndian.PutUint16(header[16:18], chk)
+	payload := make([]byte, payloadLen)
+	packet := make([]byte, len(header)+len(payload))
+	copy(packet, header)
+	copy(packet[len(header):], payload)
+	return packet
+}
+
+func writeChapter10File(t *testing.T, path string, packets ...[]byte) {
+	t.Helper()
+	var buf []byte
+	for _, pkt := range packets {
+		buf = append(buf, pkt...)
+	}
+	if err := os.WriteFile(path, buf, 0644); err != nil {
+		t.Fatalf("write Chapter 10 file: %v", err)
+	}
+}
+
+func writeTMATSFile(t *testing.T, path string) {
+	t.Helper()
+	content := "# Test TMATS\nR-1\\CHE-1:1;\nR-1\\CDT-1:PCM;\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write TMATS: %v", err)
 	}
 }

--- a/internal/tmats/parser.go
+++ b/internal/tmats/parser.go
@@ -67,6 +67,52 @@ func parseString(raw string) *Document {
 	return doc
 }
 
+// Comments returns a copy of the comment lines present in the document.
+func (d *Document) Comments() []string {
+	if d == nil {
+		return nil
+	}
+	out := make([]string, len(d.comments))
+	copy(out, d.comments)
+	return out
+}
+
+// AddComment appends a comment line when it does not already exist.
+func (d *Document) AddComment(line string) bool {
+	if d == nil {
+		return false
+	}
+	trimmed := strings.TrimSpace(strings.TrimRight(line, "\r\n"))
+	if trimmed == "" {
+		return false
+	}
+	if !strings.HasPrefix(trimmed, "#") {
+		trimmed = "# " + trimmed
+	}
+	for _, existing := range d.comments {
+		if strings.TrimSpace(existing) == trimmed {
+			return false
+		}
+	}
+	d.comments = append(d.comments, trimmed)
+	return true
+}
+
+// EnsureCommentWithTag ensures a comment containing tag exists; if not, the
+// supplied text is appended as a new comment line.
+func (d *Document) EnsureCommentWithTag(tag, text string) bool {
+	if d == nil {
+		return false
+	}
+	tag = strings.TrimSpace(tag)
+	for _, existing := range d.comments {
+		if tag != "" && strings.Contains(existing, tag) {
+			return false
+		}
+	}
+	return d.AddComment(text)
+}
+
 func (d *Document) cloneOrder() []string {
 	out := make([]string, len(d.order))
 	copy(out, d.order)


### PR DESCRIPTION
## Summary
- add a structural rewrite plan to support packet insertion, deletion, channel remap, and sequence renumbering
- implement channel remap, sequence renumber, and EnsureTimePacket fixes with modified recording TMATS annotations
- extend TMATS document helpers and update unit tests for the new behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68ce5b0160f48328aa9e12ed69eef3a6