### PR TITLE
Add offline license enforcement and release build script

### DIFF
--- a/cmd/ch10ctl/main.go
+++ b/cmd/ch10ctl/main.go
@@ -19,10 +19,20 @@ import (
 	"example.com/ch10gate/internal/rules"
 )
 
+var (
+	version   = "dev"
+	buildDate = "unknown"
+)
+
 func main() {
 	if len(os.Args) < 2 {
 		usage()
 		return
+	}
+	if _, err := common.RequireValidLicense(); err != nil {
+		fmt.Fprintf(os.Stderr, "license error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "machine hash: %s\n", machineHashForError())
+		os.Exit(2)
 	}
 	cmd := os.Args[1]
 	switch cmd {
@@ -44,7 +54,7 @@ func main() {
 }
 
 func usage() {
-	fmt.Print(`ch10ctl <command> [options]
+	fmt.Printf(`ch10ctl %s (built %s) <command> [options]
 
 Commands:
   validate  --in <file> --profile <profile> --rules <rulepack.json> --tmats <file> --out <diagnostics.jsonl> --acceptance <acceptance.json>
@@ -53,7 +63,15 @@ Commands:
   manifest  --inputs <comma-separated> --out <manifest.json> [--sign --key <key.pem> --cert <cert.pem> --jws-out <file>]
   verify-signature --manifest <manifest.json> --jws <signature.jws> --cert <cert.pem>
   batch     --in <dir> --profile <profile> --rules <rulepack.json> --out-dir <dir>
-`)
+`, version, buildDate)
+}
+
+func machineHashForError() string {
+	hash, err := common.MachineFingerprint()
+	if err != nil {
+		return fmt.Sprintf("unavailable (%v)", err)
+	}
+	return hash
 }
 
 func validateCmd(args []string) {

--- a/internal/common/license.go
+++ b/internal/common/license.go
@@ -1,0 +1,209 @@
+package common
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// License represents a validated offline license file.
+type License struct {
+	MachineHash string
+	Expiry      time.Time
+	Path        string
+}
+
+var (
+	cachedLicense *License
+	licenseErr    error
+	licenseOnce   sync.Once
+)
+
+const (
+	defaultLicenseFilename = "license.json"
+	defaultLicenseKey      = "ch10gate-license-secret"
+)
+
+// RequireValidLicense ensures that a valid license is available before executing
+// any commands. It returns the parsed license or an error that explains why the
+// license is invalid.
+func RequireValidLicense() (*License, error) {
+	licenseOnce.Do(func() {
+		cachedLicense, licenseErr = loadAndValidateLicense()
+	})
+	return cachedLicense, licenseErr
+}
+
+func loadAndValidateLicense() (*License, error) {
+	path, err := resolveLicensePath()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read license: %w", err)
+	}
+
+	var payload struct {
+		Machine   string `json:"machine"`
+		Expiry    string `json:"expiry"`
+		Signature string `json:"signature"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("parse license json: %w", err)
+	}
+
+	payload.Machine = strings.TrimSpace(payload.Machine)
+	payload.Expiry = strings.TrimSpace(payload.Expiry)
+	payload.Signature = strings.TrimSpace(payload.Signature)
+
+	if payload.Machine == "" {
+		return nil, errors.New("license machine hash is empty")
+	}
+	if payload.Expiry == "" {
+		return nil, errors.New("license expiry is empty")
+	}
+	if payload.Signature == "" {
+		return nil, errors.New("license signature is empty")
+	}
+
+	expiryDate, err := time.Parse("2006-01-02", payload.Expiry)
+	if err != nil {
+		return nil, fmt.Errorf("invalid expiry format: %w", err)
+	}
+	// Expiry is inclusive for the given day.
+	expiryCutoff := expiryDate.Add(24 * time.Hour)
+	now := time.Now().UTC()
+	if now.After(expiryCutoff) {
+		return nil, fmt.Errorf("license expired on %s", payload.Expiry)
+	}
+
+	machineHash, err := MachineFingerprint()
+	if err != nil {
+		return nil, fmt.Errorf("compute machine hash: %w", err)
+	}
+	if !strings.EqualFold(machineHash, payload.Machine) {
+		return nil, fmt.Errorf("license machine hash mismatch (expected %s, this machine %s)", payload.Machine, machineHash)
+	}
+
+	key := []byte(defaultLicenseKey)
+	if env := strings.TrimSpace(os.Getenv("CH10CTL_LICENSE_KEY")); env != "" {
+		key = []byte(env)
+	}
+	expectedSig := computeLicenseSignature(payload.Machine, payload.Expiry, key)
+	providedSig, err := hex.DecodeString(payload.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("invalid license signature encoding: %w", err)
+	}
+	if !hmac.Equal(providedSig, expectedSig) {
+		return nil, errors.New("license signature verification failed")
+	}
+
+	return &License{
+		MachineHash: machineHash,
+		Expiry:      expiryCutoff,
+		Path:        path,
+	}, nil
+}
+
+func computeLicenseSignature(machine, expiry string, key []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(machine))
+	mac.Write([]byte("|"))
+	mac.Write([]byte(expiry))
+	return mac.Sum(nil)
+}
+
+func resolveLicensePath() (string, error) {
+	candidates := licensePathCandidates()
+	for _, cand := range candidates {
+		if cand == "" {
+			continue
+		}
+		if info, err := os.Stat(cand); err == nil && !info.IsDir() {
+			return cand, nil
+		}
+	}
+	if len(candidates) == 0 {
+		return "", errors.New("no license path configured")
+	}
+	return "", fmt.Errorf("license file not found (checked: %s)", strings.Join(candidates, ", "))
+}
+
+func licensePathCandidates() []string {
+	seen := map[string]struct{}{}
+	var paths []string
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		cleaned := filepath.Clean(path)
+		if _, ok := seen[cleaned]; ok {
+			return
+		}
+		seen[cleaned] = struct{}{}
+		paths = append(paths, cleaned)
+	}
+
+	if env := strings.TrimSpace(os.Getenv("CH10CTL_LICENSE_PATH")); env != "" {
+		add(env)
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		add(filepath.Join(cwd, defaultLicenseFilename))
+	}
+	if exe, err := os.Executable(); err == nil {
+		add(filepath.Join(filepath.Dir(exe), defaultLicenseFilename))
+	}
+
+	return paths
+}
+
+// MachineFingerprint produces a stable hash for the current machine using the
+// hostname and MAC addresses. It can be shared with the vendor to generate a
+// license file.
+func MachineFingerprint() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	var components []string
+	components = append(components, strings.ToLower(hostname))
+	for _, iface := range interfaces {
+		if (iface.Flags&net.FlagLoopback) != 0 || len(iface.HardwareAddr) == 0 {
+			continue
+		}
+		components = append(components, strings.ToLower(iface.HardwareAddr.String()))
+	}
+	if len(components) == 1 {
+		// No network interfaces were added; include OS as a weak fallback.
+		components = append(components, strings.ToLower(runtime.GOOS))
+	}
+
+	hash := sha256.Sum256([]byte(strings.Join(components, "|")))
+	return hex.EncodeToString(hash[:]), nil
+}
+
+// SignLicenseForTesting is exported to help integration tests build synthetic
+// licenses without the vendor tooling.
+func SignLicenseForTesting(machineHash, expiry string, key []byte) string {
+	sig := computeLicenseSignature(machineHash, expiry, key)
+	return hex.EncodeToString(sig)
+}

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${ROOT_DIR}/dist"
+mkdir -p "${DIST_DIR}"
+
+VERSION="${VERSION:-$(git -C "${ROOT_DIR}" describe --tags --always --dirty 2>/dev/null || echo dev)}"
+BUILD_DATE="${BUILD_DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+LDFLAGS="-s -w -X main.version=${VERSION} -X main.buildDate=${BUILD_DATE}"
+
+build() {
+  local os="$1"
+  local arch="$2"
+  local output="$3"
+  echo "building ${output}"
+  GOOS="${os}" GOARCH="${arch}" CGO_ENABLED=0 \
+    go build -ldflags "${LDFLAGS}" -o "${output}" "${ROOT_DIR}/cmd/ch10ctl"
+}
+
+build linux amd64 "${DIST_DIR}/ch10ctl_${VERSION}_linux_amd64"
+build windows amd64 "${DIST_DIR}/ch10ctl_${VERSION}_windows_amd64.exe"
+
+echo "artifacts written to ${DIST_DIR}"


### PR DESCRIPTION
## Summary
- enforce offline license validation before running any ch10ctl commands and report machine fingerprint details
- add common utilities for reading signed license files tied to machine fingerprints and expiry
- add release build script that cross-compiles linux/windows binaries with injected version metadata

## Testing
- `go test ./...`
- `scripts/build_release.sh`


------
https://chatgpt.com/codex/tasks/task_b_68ce6e2bd0788328a4bfb13f29161e9d