### PR TITLE
Add REST daemon with streaming validation endpoints

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3,9 +3,38 @@ info:
   title: CH10 Gate Validator API
   version: "1.0"
 paths:
+  /upload:
+    post:
+      summary: Upload Chapter 10 or TMATS files
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: Files to upload
+              required: [files]
+      responses:
+        "200":
+          description: Uploaded files registered as artifacts
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadResponse"
   /validate:
     post:
       summary: Validate inputs and produce diagnostics + acceptance
+      parameters:
+        - name: stream
+          in: query
+          schema: {type: boolean}
+          description: When true, emit diagnostics as an application/x-ndjson stream.
       requestBody:
         required: true
         content:
@@ -14,17 +43,34 @@ paths:
               type: object
               required: [inputs, profile]
               properties:
-                inputs: {type: array, items: {type: string, description: "paths"}}
-                tmats: {type: string}
-                profile: {enum: ["106-09","106-11","106-13","106-15","106-20"]}
-                rulePack: {type: object}
+                inputs:
+                  type: array
+                  items:
+                    type: string
+                  description: Artifact IDs or file paths for Chapter 10 inputs
+                tmats:
+                  type: string
+                  description: Artifact ID or file path for TMATS metadata
+                profile:
+                  type: string
+                  enum: ["106-09", "106-11", "106-13", "106-15", "106-20"]
+                rulePack:
+                  type: object
+                  description: Optional rule pack payload overriding defaults
+                includeTimestamps:
+                  type: boolean
+                  description: Include timestamp metadata in diagnostics output
       responses:
         "200":
-          description: acceptance JSON
+          description: Acceptance JSON or NDJSON diagnostic stream
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AcceptanceReport"
+                $ref: "#/components/schemas/ValidateResponse"
+            application/x-ndjson:
+              schema:
+                type: string
+                description: Stream of Diagnostic entries followed by a summary object
   /auto-fix:
     post:
       summary: Apply auto-fixes where possible
@@ -34,20 +80,20 @@ paths:
           application/json:
             schema:
               type: object
-              required: [input, profile, rulePack]
+              required: [input, profile]
               properties:
                 input: {type: string}
                 tmats: {type: string}
-                output: {type: string}
                 profile: {type: string}
                 rulePack: {type: object}
                 dryRun: {type: boolean}
       responses:
         "200":
+          description: Diagnostics and generated fix artifacts
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FixResult"
+                $ref: "#/components/schemas/AutoFixResponse"
   /manifest:
     post:
       summary: Build a manifest with hashes
@@ -57,17 +103,21 @@ paths:
           application/json:
             schema:
               type: object
-              required: [inputs, shaAlgo]
+              required: [inputs]
               properties:
                 inputs: {type: array, items: {type: string}}
-                shaAlgo: {enum: ["sha256","sha512"]}
+                shaAlgo:
+                  type: string
+                  enum: ["sha256", "sha512"]
+                  default: "sha256"
                 sign: {type: boolean}
       responses:
         "200":
+          description: Manifest JSON with artifact reference
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Manifest"
+                $ref: "#/components/schemas/ManifestResponse"
   /profiles:
     get:
       summary: List supported profiles
@@ -78,6 +128,33 @@ paths:
               schema:
                 type: array
                 items: {type: string}
+  /artifacts/{id}:
+    get:
+      summary: Download a previously generated artifact
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: Artifact contents
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: Artifact not found
+  /openapi.yaml:
+    get:
+      summary: Retrieve the OpenAPI specification
+      responses:
+        "200":
+          content:
+            application/yaml:
+              schema:
+                type: string
 components:
   schemas:
     Diagnostic:
@@ -89,12 +166,24 @@ components:
         packetIndex: {type: integer}
         offset: {type: string}
         ruleId: {type: string}
-        severity: {enum: ["ERROR","WARN","INFO"]}
+        severity: {enum: ["ERROR", "WARN", "INFO"]}
         message: {type: string}
         refs: {type: array, items: {type: string}}
         fixSuggested: {type: boolean}
         fixApplied: {type: boolean}
         fixPatchId: {type: string}
+        timestamp_us: {type: integer, format: int64}
+        timestamp_source: {type: string}
+    GateResult:
+      type: object
+      properties:
+        ruleId: {type: string}
+        name: {type: string}
+        stage: {type: string}
+        severity: {type: string}
+        pass: {type: boolean}
+        findings: {type: integer}
+        refs: {type: array, items: {type: string}}
     AcceptanceReport:
       type: object
       properties:
@@ -105,21 +194,47 @@ components:
             errors: {type: integer}
             warnings: {type: integer}
             pass: {type: boolean}
+        gateMatrix:
+          type: array
+          items: {$ref: "#/components/schemas/GateResult"}
         findings:
           type: array
           items:
             $ref: "#/components/schemas/Diagnostic"
-    FixResult:
+    ArtifactRef:
       type: object
       properties:
-        outputFile: {type: string}
-        auditTrail:
+        id: {type: string}
+        name: {type: string}
+        contentType: {type: string}
+        size: {type: integer, format: int64}
+        kind: {type: string}
+    ValidateResponse:
+      type: object
+      properties:
+        acceptance:
+          $ref: "#/components/schemas/AcceptanceReport"
+        diagnostics: {type: integer}
+        artifacts:
           type: array
-          items: {type: object}
+          items:
+            $ref: "#/components/schemas/ArtifactRef"
+    AutoFixResponse:
+      type: object
+      properties:
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/Diagnostic"
+        outputs:
+          type: array
+          items:
+            $ref: "#/components/schemas/ArtifactRef"
     Manifest:
       type: object
       properties:
         createdAt: {type: string, format: date-time}
+        shaAlgo: {type: string}
         items:
           type: array
           items:
@@ -129,7 +244,6 @@ components:
               size: {type: integer}
               sha256: {type: string}
               type: {type: string}
-        shaAlgo: {type: string}
         signature:
           type: object
           properties:
@@ -137,3 +251,17 @@ components:
             certSubject: {type: string}
             issuer: {type: string}
             signatureFile: {type: string}
+    ManifestResponse:
+      type: object
+      properties:
+        manifest:
+          $ref: "#/components/schemas/Manifest"
+        artifact:
+          $ref: "#/components/schemas/ArtifactRef"
+    UploadResponse:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/ArtifactRef"

--- a/cmd/ch10d/main.go
+++ b/cmd/ch10d/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"example.com/ch10gate/internal/server"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address")
+	readTimeout := flag.Duration("read-timeout", 60*time.Second, "HTTP read timeout")
+	writeTimeout := flag.Duration("write-timeout", 60*time.Second, "HTTP write timeout")
+	flag.Parse()
+
+	srv, err := server.NewServer()
+	if err != nil {
+		log.Fatalf("server init: %v", err)
+	}
+	defer srv.Close()
+
+	router := server.NewRouter(srv)
+	httpServer := &http.Server{
+		Addr:         *addr,
+		Handler:      router,
+		ReadTimeout:  *readTimeout,
+		WriteTimeout: *writeTimeout,
+	}
+
+	log.Printf("ch10d listening on %s", *addr)
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %v", err)
+		}
+	}()
+
+	<-shutdown
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(ctx); err != nil {
+		log.Printf("shutdown: %v", err)
+	}
+	log.Println("ch10d stopped")
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,0 +1,578 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"example.com/ch10gate/internal/manifest"
+	"example.com/ch10gate/internal/report"
+	"example.com/ch10gate/internal/rules"
+)
+
+// Server coordinates HTTP handlers and manages temporary artifacts produced by
+// validation requests.
+type Server struct {
+	artifacts   *ArtifactStore
+	workDir     string
+	uploadsDir  string
+	profilePack map[string]string
+}
+
+// Artifact represents a file generated or stored by the daemon.
+type Artifact struct {
+	ID          string
+	Path        string
+	Name        string
+	ContentType string
+	Size        int64
+	Kind        string
+}
+
+// ArtifactRef is the public representation returned in API responses.
+type ArtifactRef struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	ContentType string `json:"contentType,omitempty"`
+	Size        int64  `json:"size,omitempty"`
+	Kind        string `json:"kind,omitempty"`
+}
+
+// ArtifactStore keeps track of generated artifacts for later download.
+type ArtifactStore struct {
+	mu      sync.RWMutex
+	entries map[string]Artifact
+}
+
+// NewServer constructs a Server rooted at a temporary workspace directory.
+func NewServer() (*Server, error) {
+	workDir, err := os.MkdirTemp("", "ch10d-")
+	if err != nil {
+		return nil, err
+	}
+	uploadsDir := filepath.Join(workDir, "uploads")
+	if err := os.MkdirAll(uploadsDir, 0o755); err != nil {
+		os.RemoveAll(workDir)
+		return nil, err
+	}
+	s := &Server{
+		artifacts:  &ArtifactStore{entries: make(map[string]Artifact)},
+		workDir:    workDir,
+		uploadsDir: uploadsDir,
+		profilePack: map[string]string{
+			"106-15": filepath.Join("profiles", "106-15", "rules-min.json"),
+		},
+	}
+	return s, nil
+}
+
+// Close removes any temporary state associated with the server.
+func (s *Server) Close() error {
+	if s == nil || s.workDir == "" {
+		return nil
+	}
+	return os.RemoveAll(s.workDir)
+}
+
+func (s *Server) tempPath(pattern string) (string, error) {
+	f, err := os.CreateTemp(s.workDir, pattern)
+	if err != nil {
+		return "", err
+	}
+	name := f.Name()
+	f.Close()
+	return name, nil
+}
+
+func (s *Server) addArtifact(path, displayName, contentType, kind string) (Artifact, error) {
+	if path == "" {
+		return Artifact{}, errors.New("empty path")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return Artifact{}, err
+	}
+	id := randomID()
+	art := Artifact{
+		ID:          id,
+		Path:        path,
+		Name:        displayName,
+		ContentType: contentType,
+		Size:        info.Size(),
+		Kind:        kind,
+	}
+	if art.Name == "" {
+		art.Name = filepath.Base(path)
+	}
+	if art.ContentType == "" {
+		art.ContentType = guessContentType(art.Name)
+	}
+	s.artifacts.mu.Lock()
+	s.artifacts.entries[id] = art
+	s.artifacts.mu.Unlock()
+	return art, nil
+}
+
+func (s *Server) getArtifact(id string) (Artifact, bool) {
+	s.artifacts.mu.RLock()
+	art, ok := s.artifacts.entries[id]
+	s.artifacts.mu.RUnlock()
+	return art, ok
+}
+
+func (s *Server) resolvePath(token string) (string, error) {
+	if token == "" {
+		return "", errors.New("empty input path")
+	}
+	if art, ok := s.getArtifact(token); ok {
+		return art.Path, nil
+	}
+	abs := token
+	if !filepath.IsAbs(token) {
+		abs = filepath.Clean(token)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	stream := r.URL.Query().Get("stream") == "true"
+	var req struct {
+		Inputs            []string        `json:"inputs"`
+		TMATS             string          `json:"tmats"`
+		Profile           string          `json:"profile"`
+		RulePack          *rules.RulePack `json:"rulePack"`
+		IncludeTimestamps *bool           `json:"includeTimestamps"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid json: %v", err), http.StatusBadRequest)
+		return
+	}
+	if len(req.Inputs) == 0 {
+		http.Error(w, "inputs required", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Profile) == "" {
+		http.Error(w, "profile required", http.StatusBadRequest)
+		return
+	}
+	inputPath, err := s.resolvePath(req.Inputs[0])
+	if err != nil {
+		http.Error(w, fmt.Sprintf("input resolve: %v", err), http.StatusBadRequest)
+		return
+	}
+	var tmatsPath string
+	if req.TMATS != "" {
+		if tmatsPath, err = s.resolvePath(req.TMATS); err != nil {
+			http.Error(w, fmt.Sprintf("tmats resolve: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
+	rp, err := s.loadRulePack(req.Profile, req.RulePack)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("load rulepack: %v", err), http.StatusBadRequest)
+		return
+	}
+	engine := rules.NewEngine(rp)
+	engine.RegisterBuiltins()
+	engine.SetConcurrency(runtime.NumCPU())
+	includeTimestamps := true
+	if req.IncludeTimestamps != nil {
+		includeTimestamps = *req.IncludeTimestamps
+	}
+	engine.SetConfigValue("diag.include_timestamps", includeTimestamps)
+	ctx := &rules.Context{InputFile: inputPath, TMATSFile: tmatsPath, Profile: req.Profile}
+
+	if stream {
+		writer := NewNDJSONWriter(w)
+		engine.SetDiagnosticCallback(func(d rules.Diagnostic) error {
+			return writer.WriteDiagnostic(d)
+		})
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		diags, err := engine.Eval(ctx)
+		engine.SetDiagnosticCallback(nil)
+		if err != nil {
+			_ = writer.WriteObject(map[string]any{
+				"type":  "error",
+				"error": err.Error(),
+			})
+			return
+		}
+		rep := engine.MakeAcceptance()
+		diagPath, err := s.tempPath("diagnostics-*.ndjson")
+		if err != nil {
+			_ = writer.WriteObject(map[string]any{"type": "error", "error": err.Error()})
+			return
+		}
+		if err := engine.WriteDiagnosticsNDJSON(diagPath); err != nil {
+			_ = writer.WriteObject(map[string]any{"type": "error", "error": err.Error()})
+			return
+		}
+		accPath, err := s.tempPath("acceptance-*.json")
+		if err != nil {
+			_ = writer.WriteObject(map[string]any{"type": "error", "error": err.Error()})
+			return
+		}
+		if err := report.SaveAcceptanceJSON(rep, accPath); err != nil {
+			_ = writer.WriteObject(map[string]any{"type": "error", "error": err.Error()})
+			return
+		}
+		diagArt, err := s.addArtifact(diagPath, filepath.Base(diagPath), "application/x-ndjson", "diagnostics")
+		if err != nil {
+			_ = writer.WriteObject(map[string]any{"type": "error", "error": err.Error()})
+			return
+		}
+		accArt, err := s.addArtifact(accPath, filepath.Base(accPath), "application/json", "acceptance")
+		if err != nil {
+			_ = writer.WriteObject(map[string]any{"type": "error", "error": err.Error()})
+			return
+		}
+		summary := struct {
+			Type       string        `json:"type"`
+			Acceptance any           `json:"acceptance"`
+			Artifacts  []ArtifactRef `json:"artifacts"`
+			Total      int           `json:"diagnostics"`
+		}{
+			Type:       "acceptance",
+			Acceptance: rep,
+			Artifacts: []ArtifactRef{
+				toRef(diagArt),
+				toRef(accArt),
+			},
+			Total: len(diags),
+		}
+		_ = writer.WriteObject(summary)
+		return
+	}
+
+	diags, err := engine.Eval(ctx)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("eval: %v", err), http.StatusInternalServerError)
+		return
+	}
+	diagPath, err := s.tempPath("diagnostics-*.ndjson")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("diagnostics temp: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if err := engine.WriteDiagnosticsNDJSON(diagPath); err != nil {
+		http.Error(w, fmt.Sprintf("write diagnostics: %v", err), http.StatusInternalServerError)
+		return
+	}
+	rep := engine.MakeAcceptance()
+	accPath, err := s.tempPath("acceptance-*.json")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("acceptance temp: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if err := report.SaveAcceptanceJSON(rep, accPath); err != nil {
+		http.Error(w, fmt.Sprintf("write acceptance: %v", err), http.StatusInternalServerError)
+		return
+	}
+	diagArt, err := s.addArtifact(diagPath, filepath.Base(diagPath), "application/x-ndjson", "diagnostics")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("register diagnostics: %v", err), http.StatusInternalServerError)
+		return
+	}
+	accArt, err := s.addArtifact(accPath, filepath.Base(accPath), "application/json", "acceptance")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("register acceptance: %v", err), http.StatusInternalServerError)
+		return
+	}
+	resp := struct {
+		Acceptance  rules.AcceptanceReport `json:"acceptance"`
+		Diagnostics int                    `json:"diagnostics"`
+		Artifacts   []ArtifactRef          `json:"artifacts"`
+	}{
+		Acceptance:  rep,
+		Diagnostics: len(diags),
+		Artifacts: []ArtifactRef{
+			toRef(diagArt),
+			toRef(accArt),
+		},
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleAutoFix(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Input    string          `json:"input"`
+		TMATS    string          `json:"tmats"`
+		Profile  string          `json:"profile"`
+		RulePack *rules.RulePack `json:"rulePack"`
+		DryRun   bool            `json:"dryRun"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid json: %v", err), http.StatusBadRequest)
+		return
+	}
+	if req.Input == "" {
+		http.Error(w, "input required", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Profile) == "" {
+		http.Error(w, "profile required", http.StatusBadRequest)
+		return
+	}
+	inputPath, err := s.resolvePath(req.Input)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("input resolve: %v", err), http.StatusBadRequest)
+		return
+	}
+	var tmatsPath string
+	if req.TMATS != "" {
+		if tmatsPath, err = s.resolvePath(req.TMATS); err != nil {
+			http.Error(w, fmt.Sprintf("tmats resolve: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
+	rp, err := s.loadRulePack(req.Profile, req.RulePack)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("load rulepack: %v", err), http.StatusBadRequest)
+		return
+	}
+	engine := rules.NewEngine(rp)
+	engine.RegisterBuiltins()
+	engine.SetConcurrency(1)
+	ctx := &rules.Context{InputFile: inputPath, TMATSFile: tmatsPath, Profile: req.Profile}
+	diags, err := engine.Eval(ctx)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("eval: %v", err), http.StatusInternalServerError)
+		return
+	}
+	seen := make(map[string]struct{})
+	var outputs []ArtifactRef
+	for _, d := range diags {
+		if !d.FixApplied || d.FixPatchId == "" {
+			continue
+		}
+		dir := filepath.Dir(d.File)
+		if dir == "" {
+			dir = filepath.Dir(inputPath)
+		}
+		candidate := filepath.Join(dir, d.FixPatchId)
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		if _, err := os.Stat(candidate); err != nil {
+			continue
+		}
+		art, err := s.addArtifact(candidate, d.FixPatchId, "", "autofix")
+		if err != nil {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		outputs = append(outputs, toRef(art))
+	}
+	resp := struct {
+		Diagnostics []rules.Diagnostic `json:"diagnostics"`
+		Outputs     []ArtifactRef      `json:"outputs"`
+	}{
+		Diagnostics: diags,
+		Outputs:     outputs,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleManifest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Inputs  []string `json:"inputs"`
+		ShaAlgo string   `json:"shaAlgo"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid json: %v", err), http.StatusBadRequest)
+		return
+	}
+	if len(req.Inputs) == 0 {
+		http.Error(w, "inputs required", http.StatusBadRequest)
+		return
+	}
+	if req.ShaAlgo == "" {
+		req.ShaAlgo = "sha256"
+	}
+	if req.ShaAlgo != "" && !strings.EqualFold(req.ShaAlgo, "sha256") {
+		http.Error(w, "only sha256 supported", http.StatusBadRequest)
+		return
+	}
+	var paths []string
+	for _, in := range req.Inputs {
+		resolved, err := s.resolvePath(in)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("resolve %s: %v", in, err), http.StatusBadRequest)
+			return
+		}
+		paths = append(paths, resolved)
+	}
+	m, err := manifest.Build(paths)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("build manifest: %v", err), http.StatusInternalServerError)
+		return
+	}
+	outPath, err := s.tempPath("manifest-*.json")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("manifest temp: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if err := manifest.Save(m, outPath); err != nil {
+		http.Error(w, fmt.Sprintf("write manifest: %v", err), http.StatusInternalServerError)
+		return
+	}
+	art, err := s.addArtifact(outPath, filepath.Base(outPath), "application/json", "manifest")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("register manifest: %v", err), http.StatusInternalServerError)
+		return
+	}
+	resp := struct {
+		Manifest manifest.Manifest `json:"manifest"`
+		Artifact ArtifactRef       `json:"artifact"`
+	}{
+		Manifest: m,
+		Artifact: toRef(art),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleProfiles(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	profiles := []string{"106-09", "106-11", "106-13", "106-15", "106-20"}
+	writeJSON(w, http.StatusOK, profiles)
+}
+
+func (s *Server) handleArtifactDownload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/artifacts/")
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	art, ok := s.getArtifact(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	f, err := os.Open(art.Path)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("open artifact: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("stat artifact: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if art.ContentType != "" {
+		w.Header().Set("Content-Type", art.ContentType)
+	}
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", info.Size()))
+	disposition := fmt.Sprintf("attachment; filename=\"%s\"", art.Name)
+	w.Header().Set("Content-Disposition", disposition)
+	io.Copy(w, f)
+}
+
+func (s *Server) handleOpenAPI(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	path := filepath.Join("api", "openapi.yaml")
+	http.ServeFile(w, r, path)
+}
+
+func (s *Server) loadRulePack(profile string, override *rules.RulePack) (rules.RulePack, error) {
+	if override != nil && len(override.Rules) > 0 {
+		return *override, nil
+	}
+	path, ok := s.profilePack[profile]
+	if !ok {
+		return rules.RulePack{}, fmt.Errorf("no default rule pack for profile %s", profile)
+	}
+	return rules.LoadRulePack(path)
+}
+
+func toRef(art Artifact) ArtifactRef {
+	return ArtifactRef{
+		ID:          art.ID,
+		Name:        art.Name,
+		ContentType: art.ContentType,
+		Size:        art.Size,
+		Kind:        art.Kind,
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(payload)
+}
+
+func guessContentType(name string) string {
+	ext := strings.ToLower(filepath.Ext(name))
+	switch ext {
+	case ".json":
+		return "application/json"
+	case ".yaml", ".yml":
+		return "application/yaml"
+	case ".ndjson":
+		return "application/x-ndjson"
+	case ".pdf":
+		return "application/pdf"
+	case ".tmats", ".tmt", ".txt":
+		return "text/plain"
+	case ".ch10", ".df10", ".tf10":
+		return "application/octet-stream"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func randomID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		now := time.Now().UTC()
+		return fmt.Sprintf("%d%06d", now.UnixNano(), os.Getpid())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func (s *Server) listArtifacts() []ArtifactRef {
+	s.artifacts.mu.RLock()
+	refs := make([]ArtifactRef, 0, len(s.artifacts.entries))
+	for _, art := range s.artifacts.entries {
+		refs = append(refs, toRef(art))
+	}
+	s.artifacts.mu.RUnlock()
+	sort.Slice(refs, func(i, j int) bool { return refs[i].ID < refs[j].ID })
+	return refs
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1,0 +1,19 @@
+package server
+
+import "net/http"
+
+// NewRouter wires HTTP routes to the server's handlers.
+func NewRouter(s *Server) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/validate", s.handleValidate)
+	mux.HandleFunc("/auto-fix", s.handleAutoFix)
+	mux.HandleFunc("/manifest", s.handleManifest)
+	mux.HandleFunc("/profiles", s.handleProfiles)
+	mux.HandleFunc("/upload", s.handleUpload)
+	mux.HandleFunc("/openapi.yaml", s.handleOpenAPI)
+	mux.HandleFunc("/artifacts/", s.handleArtifactDownload)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	return mux
+}

--- a/internal/server/upload.go
+++ b/internal/server/upload.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseMultipartForm(512 << 20); err != nil {
+		http.Error(w, fmt.Sprintf("parse multipart: %v", err), http.StatusBadRequest)
+		return
+	}
+	if r.MultipartForm == nil {
+		http.Error(w, "no files provided", http.StatusBadRequest)
+		return
+	}
+	var refs []ArtifactRef
+	for _, files := range r.MultipartForm.File {
+		for _, fh := range files {
+			ref, err := s.saveUploadedFile(fh)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("save upload %s: %v", fh.Filename, err), http.StatusBadRequest)
+				return
+			}
+			refs = append(refs, ref)
+		}
+	}
+	if len(refs) == 0 {
+		http.Error(w, "no files uploaded", http.StatusBadRequest)
+		return
+	}
+	resp := struct {
+		Files []ArtifactRef `json:"files"`
+	}{Files: refs}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) saveUploadedFile(fh *multipart.FileHeader) (ArtifactRef, error) {
+	if fh == nil {
+		return ArtifactRef{}, fmt.Errorf("nil file header")
+	}
+	src, err := fh.Open()
+	if err != nil {
+		return ArtifactRef{}, err
+	}
+	defer src.Close()
+	ext := filepath.Ext(fh.Filename)
+	pattern := "upload-*"
+	if ext != "" {
+		pattern = fmt.Sprintf("upload-*%s", ext)
+	}
+	dest, err := os.CreateTemp(s.uploadsDir, pattern)
+	if err != nil {
+		return ArtifactRef{}, err
+	}
+	if _, err := io.Copy(dest, src); err != nil {
+		dest.Close()
+		os.Remove(dest.Name())
+		return ArtifactRef{}, err
+	}
+	dest.Close()
+	art, err := s.addArtifact(dest.Name(), fh.Filename, guessContentType(fh.Filename), "upload")
+	if err != nil {
+		return ArtifactRef{}, err
+	}
+	return toRef(art), nil
+}

--- a/internal/server/write_ndjson.go
+++ b/internal/server/write_ndjson.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+
+	"example.com/ch10gate/internal/rules"
+)
+
+// NDJSONWriter streams newline-delimited JSON objects to the underlying writer.
+type NDJSONWriter struct {
+	mu      sync.Mutex
+	writer  io.Writer
+	flusher http.Flusher
+}
+
+// NewNDJSONWriter wraps the provided ResponseWriter with a helper that writes
+// newline-delimited JSON. If the writer supports http.Flusher, Flush will be
+// invoked after every write to push bytes to the client promptly.
+func NewNDJSONWriter(w http.ResponseWriter) *NDJSONWriter {
+	var flusher http.Flusher
+	if f, ok := w.(http.Flusher); ok {
+		flusher = f
+	}
+	return &NDJSONWriter{writer: w, flusher: flusher}
+}
+
+// WriteDiagnostic marshals the diagnostic and writes it as a single NDJSON
+// record.
+func (w *NDJSONWriter) WriteDiagnostic(d rules.Diagnostic) error {
+	return w.WriteObject(d)
+}
+
+// WriteObject marshals the provided value to JSON, writes it followed by a
+// newline and flushes the response.
+func (w *NDJSONWriter) WriteObject(v any) error {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if _, err := w.writer.Write(data); err != nil {
+		return err
+	}
+	if _, err := w.writer.Write([]byte("\n")); err != nil {
+		return err
+	}
+	if w.flusher != nil {
+		w.flusher.Flush()
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add a `cmd/ch10d` daemon that serves the validation REST API with graceful shutdown handling
- implement internal server handlers for uploads, validation (including NDJSON streaming), auto-fix, manifest generation, artifact downloads and OpenAPI serving
- extend the rules engine with a diagnostic callback to support streaming diagnostics and update the OpenAPI spec to describe the new endpoints and response shapes

## Testing
- go build ./cmd/ch10d
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68ce701917b88328aa3bacc4714cf652