### PR TITLE
Add daemon configuration, service definitions, and log rotation

### DIFF
--- a/cmd/ch10d/main.go
+++ b/cmd/ch10d/main.go
@@ -2,24 +2,134 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/yaml.v3"
 
 	"example.com/ch10gate/internal/server"
 )
 
+type logConfig struct {
+	Directory  string `yaml:"directory"`
+	MaxSizeMB  int    `yaml:"maxSizeMB"`
+	MaxAgeDays int    `yaml:"maxAgeDays"`
+	MaxBackups int    `yaml:"maxBackups"`
+	Compress   bool   `yaml:"compress"`
+}
+
+type config struct {
+	Port            int       `yaml:"port"`
+	StorageDir      string    `yaml:"storageDir"`
+	Concurrency     int       `yaml:"concurrency"`
+	DefaultProfile  string    `yaml:"defaultProfile"`
+	DefaultRulePack string    `yaml:"defaultRulePack"`
+	Lang            string    `yaml:"lang"`
+	Logs            logConfig `yaml:"logs"`
+}
+
+func loadConfig(path string) (config, error) {
+	var cfg config
+	f, err := os.Open(path)
+	if err != nil {
+		return cfg, err
+	}
+	defer f.Close()
+	dec := yaml.NewDecoder(f)
+	if err := dec.Decode(&cfg); err != nil {
+		return cfg, err
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 8080
+	}
+	if cfg.StorageDir == "" {
+		cfg.StorageDir = filepath.Join(".", "data")
+	}
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = runtime.NumCPU()
+	}
+	if cfg.DefaultProfile == "" || cfg.DefaultRulePack == "" {
+		return cfg, errors.New("default profile and rule pack must be configured")
+	}
+	if cfg.Lang == "" {
+		cfg.Lang = "en_US.UTF-8"
+	}
+	if cfg.Logs.Directory == "" {
+		cfg.Logs.Directory = filepath.Join(cfg.StorageDir, "logs")
+	}
+	if cfg.Logs.MaxSizeMB <= 0 {
+		cfg.Logs.MaxSizeMB = 25
+	}
+	if cfg.Logs.MaxAgeDays <= 0 {
+		cfg.Logs.MaxAgeDays = 7
+	}
+	if cfg.Logs.MaxBackups <= 0 {
+		cfg.Logs.MaxBackups = 5
+	}
+	return cfg, nil
+}
+
+func setupLogging(cfg config) error {
+	if err := os.MkdirAll(cfg.Logs.Directory, 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	logFile := filepath.Join(cfg.Logs.Directory, "ch10d.log")
+	rotator := &lumberjack.Logger{
+		Filename:   logFile,
+		MaxSize:    cfg.Logs.MaxSizeMB,
+		MaxAge:     cfg.Logs.MaxAgeDays,
+		MaxBackups: cfg.Logs.MaxBackups,
+		Compress:   cfg.Logs.Compress,
+	}
+	log.SetOutput(io.MultiWriter(os.Stdout, rotator))
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	return nil
+}
+
 func main() {
-	addr := flag.String("addr", ":8080", "listen address")
+	configPath := flag.String("config", "config/config.yaml", "path to configuration file")
+	addr := flag.String("addr", "", "listen address (overrides config port)")
 	readTimeout := flag.Duration("read-timeout", 60*time.Second, "HTTP read timeout")
 	writeTimeout := flag.Duration("write-timeout", 60*time.Second, "HTTP write timeout")
 	flag.Parse()
 
-	srv, err := server.NewServer()
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	if err := os.MkdirAll(cfg.StorageDir, 0o755); err != nil {
+		log.Fatalf("storage dir: %v", err)
+	}
+	if err := setupLogging(cfg); err != nil {
+		log.Fatalf("setup logging: %v", err)
+	}
+	if cfg.Lang != "" {
+		if err := os.Setenv("LANG", cfg.Lang); err != nil {
+			log.Printf("set LANG: %v", err)
+		}
+	}
+	listenAddr := fmt.Sprintf(":%d", cfg.Port)
+	if *addr != "" {
+		listenAddr = *addr
+	}
+	srv, err := server.NewServer(server.Options{
+		StorageDir: cfg.StorageDir,
+		ProfilePacks: map[string]string{
+			cfg.DefaultProfile: cfg.DefaultRulePack,
+		},
+		Concurrency: cfg.Concurrency,
+	})
 	if err != nil {
 		log.Fatalf("server init: %v", err)
 	}
@@ -30,13 +140,13 @@ func main() {
 		log.Fatalf("router init: %v", err)
 	}
 	httpServer := &http.Server{
-		Addr:         *addr,
+		Addr:         listenAddr,
 		Handler:      router,
 		ReadTimeout:  *readTimeout,
 		WriteTimeout: *writeTimeout,
 	}
 
-	log.Printf("ch10d listening on %s", *addr)
+	log.Printf("ch10d listening on %s", listenAddr)
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,12 @@
+port: 8080
+storageDir: ./data
+concurrency: 4
+defaultProfile: "106-15"
+defaultRulePack: "profiles/106-15/rules-min.json"
+lang: "en_US.UTF-8"
+logs:
+  directory: ./logs
+  maxSizeMB: 50
+  maxAgeDays: 14
+  maxBackups: 7
+  compress: true

--- a/deploy/systemd/ch10d.service
+++ b/deploy/systemd/ch10d.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Chapter 10 Gate validation daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ch10d
+Group=ch10d
+WorkingDirectory=/opt/ch10gate
+Environment=LANG=en_US.UTF-8
+ExecStart=/usr/local/bin/ch10d -config /etc/ch10d/config.yaml
+Restart=on-failure
+RestartSec=5s
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/windows/ch10d.xml
+++ b/deploy/windows/ch10d.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ServiceInstructions xmlns="https://example.com/ch10d/service">
+  <Overview>
+    <![CDATA[
+      Install the ch10d daemon as a Windows Service using either the native
+      SC utility or the Non-Sucking Service Manager (NSSM). The service runs
+      the compiled ch10d.exe binary and points it at the configuration file
+      installed under C:\\ProgramData\\ch10d\\config.yaml. Log rotation is
+      handled by the application itself; ensure that the directory referenced
+      by the configuration file (for example C:\\ProgramData\\ch10d\\logs)
+      exists and is writable by the service account.
+    ]]>
+  </Overview>
+  <SC>
+    <Command>sc create ch10d binPath= "C:\\Program Files\\ch10gate\\ch10d.exe -config C:\\ProgramData\\ch10d\\config.yaml" start= auto DisplayName= "Chapter 10 Gate Daemon"</Command>
+    <Command>sc description ch10d "Validates IRIG Chapter 10 recordings."</Command>
+    <Command>sc failure ch10d reset= 3600 actions= restart/5000</Command>
+  </SC>
+  <NSSM>
+    <Command>nssm install ch10d "C:\\Program Files\\ch10gate\\ch10d.exe" -config C:\\ProgramData\\ch10d\\config.yaml</Command>
+    <Parameter name="AppDirectory">C:\\Program Files\\ch10gate</Parameter>
+    <Parameter name="AppStdout">C:\\ProgramData\\ch10d\\logs\\ch10d.log</Parameter>
+    <Parameter name="AppStderr">C:\\ProgramData\\ch10d\\logs\\ch10d.log</Parameter>
+    <Parameter name="AppRotateFiles">1</Parameter>
+    <Parameter name="AppRotateSeconds">86400</Parameter>
+    <Parameter name="AppRotateBytes">52428800</Parameter>
+  </NSSM>
+  <PostInstall>
+    <![CDATA[
+      Create the service account (for example, NT SERVICE\ch10d) or run under
+      LocalService depending on organisational requirements. Grant read access
+      to the binary location and read/write access to the storage and log
+      directories referenced in config.yaml. After installation run "sc start
+      ch10d" or "nssm start ch10d" to launch the service. Verify status with
+      "sc query ch10d".
+    ]]>
+  </PostInstall>
+</ServiceInstructions>

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,8 @@ go 1.22
 
 require github.com/jung-kurt/gofpdf v1.16.2
 
-require github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
+require (
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,9 @@ github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDq
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/schemas/config.schema.json
+++ b/pkg/schemas/config.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/ch10d/config.schema.json",
+  "title": "ch10d configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "port",
+    "storageDir",
+    "concurrency",
+    "defaultProfile",
+    "defaultRulePack",
+    "lang"
+  ],
+  "properties": {
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "storageDir": {
+      "type": "string",
+      "minLength": 1
+    },
+    "concurrency": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "defaultProfile": {
+      "type": "string",
+      "minLength": 1
+    },
+    "defaultRulePack": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lang": {
+      "type": "string",
+      "minLength": 2
+    },
+    "logs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "directory"
+      ],
+      "properties": {
+        "directory": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maxSizeMB": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxAgeDays": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxBackups": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "compress": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- load configuration from YAML for ch10d and configure rotating file logging
- allow the HTTP server to accept storage, concurrency, and profile options
- document service setups with default config, schema, systemd unit, and Windows instructions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68ce8eac51088328bdc6bb199d6e5c12