### PR TITLE
Implement offline signed update installation

### DIFF
--- a/internal/crypto/jws.go
+++ b/internal/crypto/jws.go
@@ -26,6 +26,18 @@ type JWS struct {
 	Signature string `json:"signature"`
 }
 
+// ParseDetachedJWS decodes a detached JWS JSON document.
+func ParseDetachedJWS(data []byte) (JWS, error) {
+	var jws JWS
+	if err := json.Unmarshal(data, &jws); err != nil {
+		return JWS{}, err
+	}
+	if jws.Protected == "" || jws.Payload == "" || jws.Signature == "" {
+		return JWS{}, errors.New("jws missing required fields")
+	}
+	return jws, nil
+}
+
 func SignDetachedJWS(payload []byte, privateKeyPEM []byte) (JWS, error) {
 	hdr := map[string]any{
 		"alg": "RS256",

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -12,6 +12,9 @@ func NewRouter(s *Server) (http.Handler, error) {
 	mux.HandleFunc("/upload", s.handleUpload)
 	mux.HandleFunc("/openapi.yaml", s.handleOpenAPI)
 	mux.HandleFunc("/artifacts/", s.handleArtifactDownload)
+	if s.enableAdmin && s.updateInstaller != nil {
+		mux.HandleFunc("/admin/update", s.handleAdminUpdate)
+	}
 	ui, err := newUIHandler()
 	if err != nil {
 		return nil, err

--- a/internal/update/installer.go
+++ b/internal/update/installer.go
@@ -1,0 +1,327 @@
+package update
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// DefaultInstallRoot is where versioned releases are stored.
+	DefaultInstallRoot = "/opt/ch10gate"
+	// DefaultBinDir is where CLI-visible symlinks are created.
+	DefaultBinDir = "/usr/local/bin"
+	// DefaultCertPath is the trusted signer certificate.
+	DefaultCertPath = "/etc/ch10d/update_cert.pem"
+	currentLinkName = "current"
+)
+
+// Options configure an Installer.
+type Options struct {
+	InstallRoot string
+	BinDir      string
+	CertPath    string
+}
+
+// Result captures information about a successful installation.
+type Result struct {
+	Version         string
+	PreviousVersion string
+	ReleasePath     string
+}
+
+// Installer applies signed update packages to a versioned install root.
+type Installer struct {
+	opts Options
+}
+
+// NewInstaller returns an Installer with sane defaults.
+func NewInstaller(opts Options) (*Installer, error) {
+	if opts.InstallRoot == "" {
+		opts.InstallRoot = DefaultInstallRoot
+	}
+	if opts.BinDir == "" {
+		opts.BinDir = DefaultBinDir
+	}
+	if opts.CertPath == "" {
+		if env := os.Getenv("CH10_UPDATE_CERT"); env != "" {
+			opts.CertPath = env
+		} else {
+			opts.CertPath = DefaultCertPath
+		}
+	}
+	return &Installer{opts: opts}, nil
+}
+
+// InstallFromArchive verifies and installs the provided update zip archive.
+func (i *Installer) InstallFromArchive(archivePath string) (Result, error) {
+	if archivePath == "" {
+		return Result{}, errors.New("empty archive path")
+	}
+	certPEM, err := os.ReadFile(i.opts.CertPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("read cert: %w", err)
+	}
+	if err := os.MkdirAll(i.opts.InstallRoot, 0o755); err != nil {
+		return Result{}, fmt.Errorf("install root: %w", err)
+	}
+	releasesDir := filepath.Join(i.opts.InstallRoot, "releases")
+	if err := os.MkdirAll(releasesDir, 0o755); err != nil {
+		return Result{}, fmt.Errorf("releases dir: %w", err)
+	}
+	tempDir, err := os.MkdirTemp(releasesDir, "pending-")
+	if err != nil {
+		return Result{}, fmt.Errorf("extract temp: %w", err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.RemoveAll(tempDir)
+		}
+	}()
+	if err := extractArchive(archivePath, tempDir); err != nil {
+		return Result{}, err
+	}
+	pkg, err := verifyExtracted(tempDir, certPEM)
+	if err != nil {
+		return Result{}, err
+	}
+	currentVersion, err := i.InstalledVersion()
+	if err != nil {
+		return Result{}, fmt.Errorf("read installed version: %w", err)
+	}
+	if currentVersion != "" {
+		if compareVersions(pkg.Version, currentVersion) <= 0 {
+			return Result{}, fmt.Errorf("update version %s is not newer than installed %s", pkg.Version, currentVersion)
+		}
+	}
+	releaseDir := filepath.Join(releasesDir, pkg.Version)
+	if _, err := os.Stat(releaseDir); err == nil {
+		return Result{}, fmt.Errorf("version %s already installed", pkg.Version)
+	}
+	if err := os.Rename(tempDir, releaseDir); err != nil {
+		return Result{}, fmt.Errorf("activate release: %w", err)
+	}
+	cleanup = false
+	if err := i.swapCurrentSymlink(releaseDir); err != nil {
+		return Result{}, err
+	}
+	if err := i.ensureBinSymlinks(releaseDir); err != nil {
+		return Result{}, err
+	}
+	return Result{Version: pkg.Version, PreviousVersion: currentVersion, ReleasePath: releaseDir}, nil
+}
+
+// InstalledVersion returns the currently active version, if any.
+func (i *Installer) InstalledVersion() (string, error) {
+	currentPath := filepath.Join(i.opts.InstallRoot, currentLinkName)
+	target, err := os.Readlink(currentPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(currentPath), target)
+	}
+	versionBytes, err := os.ReadFile(filepath.Join(target, "VERSION"))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(versionBytes)), nil
+}
+
+func (i *Installer) swapCurrentSymlink(releaseDir string) error {
+	currentPath := filepath.Join(i.opts.InstallRoot, currentLinkName)
+	tmp := currentPath + ".tmp"
+	_ = os.Remove(tmp)
+	if err := os.Symlink(releaseDir, tmp); err != nil {
+		return fmt.Errorf("create tmp symlink: %w", err)
+	}
+	if err := os.Rename(tmp, currentPath); err != nil {
+		return fmt.Errorf("activate symlink: %w", err)
+	}
+	return nil
+}
+
+func (i *Installer) ensureBinSymlinks(releaseDir string) error {
+	binDir := filepath.Join(releaseDir, "bin")
+	entries, err := os.ReadDir(binDir)
+	if err != nil {
+		return fmt.Errorf("read bin dir: %w", err)
+	}
+	if err := os.MkdirAll(i.opts.BinDir, 0o755); err != nil {
+		return fmt.Errorf("bin dir: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() {
+			continue
+		}
+		name := entry.Name()
+		target := filepath.Join(i.opts.InstallRoot, currentLinkName, "bin", name)
+		linkPath := filepath.Join(i.opts.BinDir, name)
+		tmp := linkPath + ".tmp"
+		_ = os.Remove(tmp)
+		if err := os.Symlink(target, tmp); err != nil {
+			return fmt.Errorf("create symlink for %s: %w", name, err)
+		}
+		if err := os.Rename(tmp, linkPath); err != nil {
+			return fmt.Errorf("activate symlink for %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func extractArchive(archivePath, dest string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("open archive: %w", err)
+	}
+	defer r.Close()
+	for _, file := range r.File {
+		name := filepath.Clean(file.Name)
+		if name == "." || strings.HasPrefix(name, "../") || strings.Contains(name, ":") {
+			return fmt.Errorf("archive entry %q invalid", file.Name)
+		}
+		if strings.HasPrefix(name, "__MACOSX") {
+			continue
+		}
+		targetPath := filepath.Join(dest, name)
+		rel, err := filepath.Rel(dest, targetPath)
+		if err != nil {
+			return fmt.Errorf("normalise %s: %w", file.Name, err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("archive entry %q escapes destination", file.Name)
+		}
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", targetPath, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(targetPath), err)
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return fmt.Errorf("open entry %s: %w", file.Name, err)
+		}
+		mode := file.Mode()
+		if mode == 0 {
+			mode = 0o644
+		}
+		out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+		if err != nil {
+			rc.Close()
+			return fmt.Errorf("create %s: %w", targetPath, err)
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			out.Close()
+			rc.Close()
+			return fmt.Errorf("extract %s: %w", file.Name, err)
+		}
+		out.Close()
+		rc.Close()
+	}
+	return nil
+}
+
+func compareVersions(a, b string) int {
+	if a == b {
+		return 0
+	}
+	ap := parseVersionParts(a)
+	bp := parseVersionParts(b)
+	n := len(ap)
+	if len(bp) > n {
+		n = len(bp)
+	}
+	for i := 0; i < n; i++ {
+		ai := 0
+		if i < len(ap) {
+			ai = ap[i]
+		}
+		bi := 0
+		if i < len(bp) {
+			bi = bp[i]
+		}
+		if ai > bi {
+			return 1
+		}
+		if ai < bi {
+			return -1
+		}
+	}
+	if len(ap) > len(bp) {
+		return 1
+	}
+	if len(ap) < len(bp) {
+		return -1
+	}
+	return strings.Compare(a, b)
+}
+
+func parseVersionParts(s string) []int {
+	parts := strings.Split(s, ".")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			out = append(out, 0)
+			continue
+		}
+		v := 0
+		for _, ch := range p {
+			if ch < '0' || ch > '9' {
+				v = -1
+				break
+			}
+			v = v*10 + int(ch-'0')
+		}
+		if v < 0 {
+			return []int{0}
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// FindArchive locates a single .update.zip archive within dir.
+func FindArchive(dir string) (string, error) {
+	if dir == "" {
+		return "", errors.New("empty directory")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", dir)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	matches := make([]string, 0, 1)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(strings.ToLower(name), ".update.zip") {
+			matches = append(matches, filepath.Join(dir, name))
+		}
+	}
+	if len(matches) == 0 {
+		return "", errors.New("no .update.zip archive found")
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("multiple .update.zip archives found in %s", dir)
+	}
+	return matches[0], nil
+}

--- a/internal/update/verify.go
+++ b/internal/update/verify.go
@@ -1,0 +1,157 @@
+package update
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"example.com/ch10gate/internal/common"
+	"example.com/ch10gate/internal/crypto"
+	"example.com/ch10gate/internal/manifest"
+)
+
+// Package represents the contents of an update package after it has been
+// extracted to disk and verified against its manifest signature.
+type Package struct {
+	Root     string
+	Version  string
+	Manifest manifest.Manifest
+}
+
+// verifyExtracted performs signature verification and structural validation on
+// the extracted update directory.
+func verifyExtracted(root string, certPEM []byte) (Package, error) {
+	if root == "" {
+		return Package{}, errors.New("empty root")
+	}
+	manifestPath := filepath.Join(root, "MANIFEST.json")
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return Package{}, fmt.Errorf("read manifest: %w", err)
+	}
+	sigPath := filepath.Join(root, "SIGNATURE.jws")
+	sigBytes, err := os.ReadFile(sigPath)
+	if err != nil {
+		return Package{}, fmt.Errorf("read signature: %w", err)
+	}
+	jws, err := crypto.ParseDetachedJWS(sigBytes)
+	if err != nil {
+		return Package{}, fmt.Errorf("parse jws: %w", err)
+	}
+	if err := crypto.VerifyDetachedJWS(manifestBytes, jws, certPEM); err != nil {
+		return Package{}, fmt.Errorf("verify signature: %w", err)
+	}
+	var mani manifest.Manifest
+	if err := json.Unmarshal(manifestBytes, &mani); err != nil {
+		return Package{}, fmt.Errorf("parse manifest: %w", err)
+	}
+	if mani.ShaAlgo != "sha256" {
+		return Package{}, fmt.Errorf("unsupported manifest algorithm %q", mani.ShaAlgo)
+	}
+	if len(mani.Items) == 0 {
+		return Package{}, errors.New("manifest has no items")
+	}
+	if err := validateManifestItems(root, mani.Items); err != nil {
+		return Package{}, err
+	}
+	versionPath := filepath.Join(root, "VERSION")
+	versionBytes, err := os.ReadFile(versionPath)
+	if err != nil {
+		return Package{}, fmt.Errorf("read version: %w", err)
+	}
+	version := strings.TrimSpace(string(versionBytes))
+	if version == "" {
+		return Package{}, errors.New("empty version in package")
+	}
+	if err := ensureRequiredFiles(root); err != nil {
+		return Package{}, err
+	}
+	return Package{Root: root, Version: version, Manifest: mani}, nil
+}
+
+func ensureRequiredFiles(root string) error {
+	required := []string{"LICENSE", "VERSION", "bin"}
+	for _, name := range required {
+		path := filepath.Join(root, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("package missing %s: %w", name, err)
+		}
+		if name == "bin" && !info.IsDir() {
+			return errors.New("package bin entry is not a directory")
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "bin"))
+	if err != nil {
+		return fmt.Errorf("read bin dir: %w", err)
+	}
+	hasBinary := false
+	for _, entry := range entries {
+		if entry.Type().IsRegular() {
+			hasBinary = true
+			break
+		}
+	}
+	if !hasBinary {
+		return errors.New("package bin directory empty")
+	}
+	return nil
+}
+
+func validateManifestItems(root string, items []manifest.Item) error {
+	seenVersion := false
+	seenLicense := false
+	binEntries := 0
+	for _, item := range items {
+		if strings.TrimSpace(item.Path) == "" {
+			return errors.New("manifest item missing path")
+		}
+		cleaned := filepath.Clean(item.Path)
+		if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+			return fmt.Errorf("manifest item %q escapes package root", item.Path)
+		}
+		if filepath.IsAbs(cleaned) {
+			return fmt.Errorf("manifest item %q is absolute", item.Path)
+		}
+		path := filepath.Join(root, cleaned)
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("manifest item %q: %w", item.Path, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("manifest item %q is a directory", item.Path)
+		}
+		hash, size, err := common.Sha256OfFile(path)
+		if err != nil {
+			return fmt.Errorf("hash %q: %w", item.Path, err)
+		}
+		if hash != item.Sha256 {
+			return fmt.Errorf("manifest mismatch for %s", item.Path)
+		}
+		if size != item.Size {
+			return fmt.Errorf("manifest size mismatch for %s", item.Path)
+		}
+		switch cleaned {
+		case "VERSION":
+			seenVersion = true
+		case "LICENSE":
+			seenLicense = true
+		}
+		if strings.HasPrefix(cleaned, "bin/") {
+			binEntries++
+		}
+	}
+	if !seenVersion {
+		return errors.New("manifest missing VERSION entry")
+	}
+	if !seenLicense {
+		return errors.New("manifest missing LICENSE entry")
+	}
+	if binEntries == 0 {
+		return errors.New("manifest missing binaries")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add an internal update installer that verifies signed packages, blocks downgrades, and swaps versioned releases atomically
- expose the installer through a new `ch10ctl update` command and a gated `/admin/update` REST endpoint
- extend the daemon and crypto utilities to support the new flows

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68ce90a162148328b39c519dc34747a1